### PR TITLE
Player stamina

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/player/PlayerActions.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerActions.java
@@ -13,26 +13,52 @@ import com.badlogic.gdx.utils.Timer;
  * and when triggered should call methods within this class.
  */
 public class PlayerActions extends Component {
-  private static final Vector2 MAX_SPEED = new Vector2(3f, 3f); // Metres per second
+  // Managers
+  private Timer.Task staminaTask;
+  private PhysicsComponent physicsComponent;
+
+  // Movement Constants
+  private static final Vector2 MAX_SPEED    = new Vector2(3f, 3f);
   private static final Vector2 CROUCH_SPEED = new Vector2(1.5f, 3f);
   private static final Vector2 SPRINT_SPEED = new Vector2(7f, 3f);
   private static final Vector2 JUMP_VELOCITY = new Vector2(0f, 120f);
   private static final Vector2 DASH_SPEED = new Vector2(20f, 9.8f);
-  private int DASH_COOLDOWN = 15; // In hundredths of a second so equals 1.5 seconds
+  private static final float DASH_DURATION = 0.1f;
+  private int DASH_COOLDOWN = 15; // hundredths of a second (1.5s)
 
-  private PhysicsComponent physicsComponent;
+  // Stamina Constants
+  private static final int MAX_STAMINA = 100;
+  private static final int INITIAL_STAMINA = 100;
+  private static final float SPRINT_DRAIN_PER_SEC = 15f; // whilst moving or jumping normally
+  private static final float SPRINT_REGEN_PER_SEC = 10f; // stamina/sec when not spending
+  private static final int DASH_COST = 30; // stamina instantly consumed on dash
+  private static final int DOUBLE_JUMP_COST = 10; // stamina consumed on air jump
+  private static final long STAMINA_REGEN_DELAY_MS = 800; // time between last spend to regen
+  private static final float STAMINA_TICK_SEC = 0.1f;
+
+  // Jumping Limits
+  private static final int MAX_JUMPS = 2;
+  private static final long JUMP_COOLDOWN_MS = 300;
+
+  // Internal variables to manage movement
   private Vector2 walkDirection = Vector2.Zero.cpy();
   private boolean moving = false;
-  private boolean sprinting = false; // If 'Left Shift' is held
+  private boolean sprinting = false;
   private boolean facingRight = true;
   private boolean dashing = false;
-  private int dashCooldown = 0;
   private boolean crouching = false;
-  private static final int MAX_JUMPS = 2; // allow 1 normal jump + 1 double jump
+
+  // Ability cooldowns / counters
+  private int dashCooldown= 0;
   private int jumpsLeft = MAX_JUMPS;
   private long lastJumpTime = 0; // timestamp of last ground jump
-  private static final long JUMP_COOLDOWN_MS = 300; // 300ms between jumps
-  private static final float DASH_DURATION = 0.1f;
+
+  // Stamina management
+  private float stamina = INITIAL_STAMINA;
+  private long  lastStaminaSpendMs = 0L;
+  private boolean infiniteStamina = false;  // used for cheatcodes
+  // Tracks the last integer stamina value we pushed to UI to avoid redundant events
+  private int lastEmittedStamina = -1;
 
   @Override
   public void create() {
@@ -47,6 +73,9 @@ public class PlayerActions extends Component {
     entity.getEvents().addListener("crouchStop", () -> crouching = false);
     entity.getEvents().addListener("sprintStart", () -> sprinting = true);
     entity.getEvents().addListener("sprintStop",  () -> sprinting = false);
+
+    startStaminaTask();
+    emitStaminaChanged();
   }
 
   @Override
@@ -82,7 +111,8 @@ public class PlayerActions extends Component {
       if (crouching) {
         maxX = CROUCH_SPEED.x;
       } else {
-        maxX = (sprinting && hasDir) ? SPRINT_SPEED.x : MAX_SPEED.x;
+        boolean allowSprint = sprinting && hasDir && stamina > 0f;
+        maxX = allowSprint ? SPRINT_SPEED.x : MAX_SPEED.x;
       }
       targetVx = walkDirection.x * maxX;
     }
@@ -130,23 +160,36 @@ public class PlayerActions extends Component {
 
     if (jumpsLeft > 0) {
       boolean isGroundJump = (jumpsLeft == MAX_JUMPS); // first jump
-      if (!isGroundJump || (currentTime - lastJumpTime) > JUMP_COOLDOWN_MS) {
-        body.applyLinearImpulse(JUMP_VELOCITY, body.getWorldCenter(), true);
-        jumpsLeft--;
-        lastJumpTime = currentTime;
+
+      if (isGroundJump) {
+        if ((currentTime - lastJumpTime) <= JUMP_COOLDOWN_MS) {
+          // Player still on jump cooldown
+          return;
+        }
+      } else {
+        if (!trySpendStamina(DOUBLE_JUMP_COST)) {
+          // Player lacks stamina
+          return;
+        }
       }
+
+      // Apply jump
+      body.applyLinearImpulse(JUMP_VELOCITY, body.getWorldCenter(), true);
+      jumpsLeft--;
+      lastJumpTime = currentTime;
     }
   }
 
   void sprintAttempt() {
-    if (!crouching) {
+    if (!crouching && hasStamina()) {
       sprinting = true;
       entity.getEvents().trigger("sprintStart");
     }
   }
 
   void dash() {
-    if (dashCooldown == 0) {
+    if (dashCooldown == 0 && trySpendStamina(DASH_COST)) {
+      // Player has no cooldown and sufficient stamina
       if (crouching) { // Need to add grounded check here as well
         entity.getEvents().trigger("roll", facingRight); // Different animation
       } else {
@@ -201,6 +244,132 @@ public class PlayerActions extends Component {
   }
 
   /**
+   * Checks if the player has any stamina left.
+   * @return boolean indicating if the player has stamina.
+   */
+  private boolean hasStamina() {
+    return stamina > 0f;
+  }
+
+  /**
+   * Starts (or restarts) the repeating stamina update task.
+   * Uses libGDX {@link Timer} so that ticks are posted onto the main render thread.
+   * Idempotent: if a task is already running it will be cancelled and replaced.
+   */
+  private void startStaminaTask() {
+    // Ensure there is only ever one repeating task running
+    if (staminaTask != null) {
+      staminaTask.cancel();
+      staminaTask = null;
+    }
+    staminaTask = Timer.schedule(new Timer.Task() {
+      @Override
+      public void run() {
+        staminaTick();
+      }
+    }, STAMINA_TICK_SEC, STAMINA_TICK_SEC); // initial delay, then fixed interval
+  }
+
+  /**
+   * Cancels the repeating stamina task when this component is disposed to prevent leaks.
+   */
+  @Override
+  public void dispose() {
+    super.dispose();
+    if (staminaTask != null) {
+      staminaTask.cancel();
+      staminaTask = null;
+    }
+  }
+
+  /**
+   * One stamina "tick". Called at a fixed cadence by {@link #startStaminaTask()}.
+   * Checks for horizontal movement. Jumps, dashes and other special movement actions
+   * stamina changes are implemented in the handlers respectively.
+   *
+   * Rules:
+   * - If {@code infiniteStamina} is enabled, keep stamina pegged at MAX and notify UI.
+   * - While sprinting and moving horizontally (and not dashing), drain stamina.
+   * - If not spending for {@code STAMINA_REGEN_DELAY_MS}, regenerate up to MAX.
+   * - UI is only notified when the integer stamina value actually changes.
+   */
+  private void staminaTick() {
+    final long now = System.currentTimeMillis();
+
+    // Cheat mode: keep stamina maxed and notify UI if it changed.
+    if (infiniteStamina) {
+      stamina = MAX_STAMINA;
+      emitStaminaChanged();
+      return;
+    }
+
+    // Drain if actively sprinting and actually moving horizontally (not dashing)
+    final boolean actuallySprinting =
+        sprinting && moving && Math.abs(walkDirection.x) > 0.0001f && !dashing;
+
+    if (actuallySprinting && stamina > 0f) {
+      final float drainPerTick = SPRINT_DRAIN_PER_SEC * STAMINA_TICK_SEC;
+      stamina = Math.max(0f, stamina - drainPerTick);
+      lastStaminaSpendMs = now;
+
+      if ((int) stamina == 0) {
+        // Auto-cancel sprint when we run dry.
+        sprinting = false;
+        entity.getEvents().trigger("sprintStop");
+        entity.getEvents().trigger("outOfStamina");
+      }
+      emitStaminaChanged(); // only emits if value changed
+      return; // If draining we don't regen in the same tick.
+    }
+
+    // Regenerate if we haven't spent for a while and we're not dashing.
+    if (!dashing && (now - lastStaminaSpendMs) >= STAMINA_REGEN_DELAY_MS) {
+      final float regenPerTick = SPRINT_REGEN_PER_SEC * STAMINA_TICK_SEC;
+      final float before = stamina;
+      stamina = Math.min(MAX_STAMINA, stamina + regenPerTick);
+      if ((int) stamina != (int) before) {
+        emitStaminaChanged();
+      }
+    }
+  }
+
+  /**
+   * Attempts to spend the given amount of stamina.
+   *
+   * @param amount positive stamina cost
+   * @return true if the cost was paid (or stamina is infinite); false if not enough stamina
+   */
+  private boolean trySpendStamina(int amount) {
+    if (infiniteStamina) {
+      return true;
+    }
+    if (amount <= 0) {
+      // Non-positive costs are considered free.
+      return true;
+    }
+    if (stamina >= amount) {
+      stamina -= amount;
+      lastStaminaSpendMs = System.currentTimeMillis();
+      emitStaminaChanged();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Emits a stamina change event to the UI layer, but only if the integer value
+   * has actually changed since the last emission. This avoids redundant UI work.
+   */
+  private void emitStaminaChanged() {
+    final int current = (int) stamina;
+    if (current == lastEmittedStamina) {
+      return;
+    }
+    lastEmittedStamina = current;
+    entity.getEvents().trigger("staminaChanged", current, MAX_STAMINA);
+  }
+
+  /**
    * Cheatcode: infinite dashes
    */
   public void infDash() {
@@ -212,5 +381,14 @@ public class PlayerActions extends Component {
    */
   public void infJumps() {
     this.jumpsLeft = 9999;
+  }
+
+  /**
+   * Cheatcode: infinite stamina
+   */
+  public void infStamina() {
+    this.infiniteStamina = true;
+    this.stamina = MAX_STAMINA;
+    emitStaminaChanged();
   }
 }

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerStatsDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerStatsDisplay.java
@@ -2,11 +2,9 @@ package com.csse3200.game.components.player;
 
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.csse3200.game.components.CombatStatsComponent;
-import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.ui.UIComponent;
 
 import com.badlogic.gdx.graphics.Color;
@@ -17,12 +15,28 @@ import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.csse3200.game.components.player.InventoryComponent;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A ui component for displaying player stats, e.g. health.
  */
 public class PlayerStatsDisplay extends UIComponent {
+  // UI constants
+  private static final float BAR_WIDTH = 200f;
+  private static final float BAR_HEIGHT = 30f;
+
+  // Colours
+  private static final Color COLOR_BG  = Color.DARK_GRAY;
+  private static final Color COLOR_HEALTH = Color.RED;
+  private static final Color COLOR_STAMINA = Color.GREEN;
+
+  // Track textures we create so we can dispose them explicitly
+  private final List<Texture> disposableTextures = new ArrayList<>();
+
   private Table table;
   private ProgressBar healthBar;
+  private ProgressBar staminaBar;
   private Label processorLabel;
 
   /**
@@ -35,6 +49,7 @@ public class PlayerStatsDisplay extends UIComponent {
 
     entity.getEvents().addListener("updateHealth", this::updatePlayerHealthUI);
     entity.getEvents().addListener("updateProcessor", this::updatePlayerProcessorUI);
+    entity.getEvents().addListener("staminaChanged", this::updatePlayerStaminaUI);
   }
 
   /**
@@ -46,7 +61,19 @@ public class PlayerStatsDisplay extends UIComponent {
     pixmap.fill();
     Texture texture = new Texture(pixmap);
     pixmap.dispose();
+    disposableTextures.add(texture);
     return new TextureRegionDrawable(new TextureRegion(texture));
+  }
+
+  /** Creates a simple horizontal bar style with a colored fill and dark background. */
+  private ProgressBar.ProgressBarStyle makeBarStyle(Color fill, float barHeight) {
+    ProgressBar.ProgressBarStyle style = new ProgressBar.ProgressBarStyle();
+    style.background = makeColorDrawable(COLOR_BG);
+    style.background.setMinHeight(barHeight);
+    style.knobBefore = makeColorDrawable(fill);
+    style.knobBefore.setMinHeight(barHeight);
+    style.knob = null;
+    return style;
   }
 
   /**
@@ -59,32 +86,34 @@ public class PlayerStatsDisplay extends UIComponent {
     table.setFillParent(true);
     table.padTop(45f).padLeft(5f);
 
-    // Health bar size
-    float barWidth = 200f;
-    float barHeight = 30f;
-
-    // Setting health bar attributes
-    ProgressBar.ProgressBarStyle healthBarStyle = new ProgressBar.ProgressBarStyle();
-    healthBarStyle.background = makeColorDrawable(Color.DARK_GRAY);
-    healthBarStyle.background.setMinHeight(barHeight);
-    healthBarStyle.knobBefore = makeColorDrawable(Color.RED);
-    healthBarStyle.knobBefore.setMinHeight(barHeight);
-    healthBarStyle.knob = null;
-
+    // Health bar
+    ProgressBar.ProgressBarStyle healthBarStyle = makeBarStyle(COLOR_HEALTH, BAR_HEIGHT);
     int health = entity.getComponent(CombatStatsComponent.class).getHealth();
-    // Health bar creation, currently hardcoded to be max of 100
     healthBar = new ProgressBar(0, 100, 1, false, healthBarStyle);
     healthBar.setValue(health);
-    healthBar.setAnimateDuration(0.0f);
+    healthBar.setAnimateDuration(0f);
 
-    // processor text
+    // Stamina bar (0..100 shows percent so UI is decoupled from gameplay max)
+    ProgressBar.ProgressBarStyle staminaStyle = makeBarStyle(COLOR_STAMINA, BAR_HEIGHT);
+    staminaBar = new ProgressBar(0, 100, 1, false, staminaStyle);
+    staminaBar.setValue(100);
+    staminaBar.setAnimateDuration(0f);
+
+    // Processor label
     int processor = entity.getComponent(InventoryComponent.class).getProcessor();
     CharSequence processorText = String.format("Processor: %d", processor);
     processorLabel = new Label(processorText, skin, "large");
 
-    table.add(healthBar).width(barWidth).height(barHeight).pad(5);
+    // Layout:
+    // Row 1: Health bar
+    table.add(healthBar).width(BAR_WIDTH).height(BAR_HEIGHT).pad(5);
     table.row();
-    table.add(processorLabel);
+    // Row 2: Stamina bar
+    table.add(staminaBar).width(BAR_WIDTH).height(BAR_HEIGHT).pad(5);
+    table.row();
+    // Row 3: Processor label
+    table.add(processorLabel).left().padLeft(10f);
+
     stage.addActor(table);
   }
 
@@ -102,6 +131,18 @@ public class PlayerStatsDisplay extends UIComponent {
   }
 
   /**
+   * Updates the player's stamina on the UI.
+   * @param current the current stamina value
+   * @param max the max stamina
+   */
+  public void updatePlayerStaminaUI(int current, int max) {
+    float pct = (current * 100f) / max;
+    if (pct < 0f) pct = 0f;
+    if (pct > 100f) pct = 100f;
+    staminaBar.setValue(pct);
+  }
+
+  /**
    * Updates the player's processor on the UI.
    * @param processor player processor
    */
@@ -113,7 +154,15 @@ public class PlayerStatsDisplay extends UIComponent {
   @Override
   public void dispose() {
     super.dispose();
-    healthBar.remove();
-    processorLabel.remove();
+    if (healthBar != null) healthBar.remove();
+    if (staminaBar != null) staminaBar.remove();
+    if (processorLabel != null) processorLabel.remove();
+    // Dispose textures we created for the drawables
+    for (Texture tex : disposableTextures) {
+      if (tex != null) {
+        tex.dispose();
+      }
+    }
+    disposableTextures.clear();
   }
 }

--- a/source/core/src/test/com/csse3200/game/components/player/PlayerStaminaTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/PlayerStaminaTest.java
@@ -1,0 +1,265 @@
+package com.csse3200.game.components.player;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.*;
+
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.physics.box2d.Body;
+import com.csse3200.game.extensions.GameExtension;
+import com.csse3200.game.physics.PhysicsService;
+import com.csse3200.game.physics.components.PhysicsComponent;
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.events.EventHandler;
+import com.csse3200.game.services.ServiceLocator;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests stamina drain/regen logic, double-jump cost, and the infinite stamina cheat.
+ * We avoid the Timer by calling the private staminaTick() via reflection.
+ */
+@ExtendWith(GameExtension.class)
+class PlayerStaminaTest {
+
+    @BeforeEach
+    void setup() {
+        ServiceLocator.registerPhysicsService(new PhysicsService());
+    }
+
+    // Helpers
+    private static void attachEntity(PlayerActions actions) {
+        Entity ent = mock(Entity.class);
+        EventHandler events = new EventHandler();
+        when(ent.getEvents()).thenReturn(events);
+        setField(actions, "entity", ent);
+    }
+
+    private static Field findField(Class<?> clazz, String name) {
+        Class<?> c = clazz;
+        while (c != null) {
+            try {
+                Field f = c.getDeclaredField(name);
+                f.setAccessible(true);
+                return f;
+            } catch (NoSuchFieldException ignored) {
+                c = c.getSuperclass();
+            }
+        }
+        throw new RuntimeException(new NoSuchFieldException(name));
+    }
+
+    private static float reflectFloat(Object target, String name) {
+        try {
+            Field f = findField(target.getClass(), name);
+            return f.getFloat(target);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static int reflectIntConst(Class<?> clazz, String name, int fallback) {
+        try {
+            Field f = clazz.getDeclaredField(name);
+            f.setAccessible(true);
+            return f.getInt(null);
+        } catch (Exception ignored) {
+            return fallback;
+        }
+    }
+
+    private static float reflectFloatConst(Class<?> clazz, String name, float fallback) {
+        try {
+            Field f = clazz.getDeclaredField(name);
+            f.setAccessible(true);
+            return f.getFloat(null);
+        } catch (Exception ignored) {
+            return fallback;
+        }
+    }
+
+    private static long reflectLongConst(Class<?> clazz, String name, long fallback) {
+        try {
+            Field f = clazz.getDeclaredField(name);
+            f.setAccessible(true);
+            return f.getLong(null);
+        } catch (Exception ignored) {
+            return fallback;
+        }
+    }
+
+    private static void setField(Object target, String name, Object value) {
+        try {
+            Field f = findField(target.getClass(), name);
+            f.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void callPrivate(Object target, String method) {
+        try {
+            Method m = target.getClass().getDeclaredMethod(method);
+            m.setAccessible(true);
+            m.invoke(target);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean callTrySpend(Object target, int amount) {
+        try {
+            Method m = target.getClass().getDeclaredMethod("trySpendStamina", int.class);
+            m.setAccessible(true);
+            Object out = m.invoke(target, amount);
+            return (Boolean) out;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+    // -----------------------------------------------
+
+    @Test
+    void sprintingDrainsStamina() {
+        PlayerActions actions = new PlayerActions();
+        attachEntity(actions);
+
+        // Arrange: pretend we are sprinting and moving right, not dashing
+        setField(actions, "sprinting", true);
+        setField(actions, "moving", true);
+        setField(actions, "dashing", false);
+        setField(actions, "walkDirection", new Vector2(1f, 0f));
+        setField(actions, "stamina", 50f);
+
+        float tick = reflectFloatConst(PlayerActions.class, "STAMINA_TICK_SEC", 0.1f);
+        float drainPerSec = reflectFloatConst(PlayerActions.class, "SPRINT_DRAIN_PER_SEC", 15f);
+
+        // Act
+        callPrivate(actions, "staminaTick");
+
+        // Assert: drained by (drain/sec * tick)
+        float staminaAfter = reflectFloat(actions, "stamina");
+        float expected = Math.max(0f, 50f - drainPerSec * tick);
+        assertEquals(expected, staminaAfter, 1e-4);
+    }
+
+    @Test
+    void notMovingDoesNotDrain() {
+        PlayerActions actions = new PlayerActions();
+        attachEntity(actions);
+
+        setField(actions, "sprinting", true);
+        setField(actions, "moving", false); // stationary
+        setField(actions, "dashing", false);
+        setField(actions, "walkDirection", new Vector2(0f, 0f));
+        setField(actions, "stamina", 40f);
+
+        // Make regen NOT trigger yet by pretending we just spent
+        long now = System.currentTimeMillis();
+        setField(actions, "lastStaminaSpendMs", now);
+
+        callPrivate(actions, "staminaTick");
+
+        float staminaAfter = reflectFloat(actions, "stamina");
+        assertEquals(40f, staminaAfter, 1e-4);
+    }
+
+    @Test
+    void regeneratesAfterDelay() {
+        PlayerActions actions = new PlayerActions();
+        attachEntity(actions);
+
+        setField(actions, "sprinting", false);
+        setField(actions, "moving", false);
+        setField(actions, "dashing", false);
+        setField(actions, "walkDirection", new Vector2(0f, 0f));
+        setField(actions, "stamina", 60f);
+
+        long delayMs = reflectLongConst(PlayerActions.class, "STAMINA_REGEN_DELAY_MS", 800L);
+        // Pretend we last spent long enough ago
+        setField(actions, "lastStaminaSpendMs", System.currentTimeMillis() - delayMs - 1);
+
+        float tick = reflectFloatConst(PlayerActions.class, "STAMINA_TICK_SEC", 0.1f);
+        float regenPerSec = reflectFloatConst(PlayerActions.class, "SPRINT_REGEN_PER_SEC", 10f);
+
+        callPrivate(actions, "staminaTick");
+
+        float staminaAfter = reflectFloat(actions, "stamina");
+        float expected = Math.min(
+                reflectIntConst(PlayerActions.class, "MAX_STAMINA", 100),
+                60f + regenPerSec * tick
+        );
+        assertEquals(expected, staminaAfter, 1e-4);
+    }
+
+    @Test
+    void trySpendStaminaFailsWhenInsufficient_andSucceedsWhenEnough() {
+        PlayerActions actions = new PlayerActions();
+        attachEntity(actions);
+
+        setField(actions, "stamina", 5f);
+        assertFalse(callTrySpend(actions, 10)); // not enough -> false
+        assertEquals(5f, reflectFloat(actions, "stamina"), 1e-4);
+
+        setField(actions, "stamina", 20f);
+        assertTrue(callTrySpend(actions, 10)); // enough -> true and reduced
+        assertEquals(10f, reflectFloat(actions, "stamina"), 1e-4);
+    }
+
+    @Test
+    void doubleJumpSpendsStamina_andBlocksWithoutIt() throws Exception {
+        // Mock physics so jump can apply impulses safely
+        PhysicsComponent physicsComponent = mock(PhysicsComponent.class);
+        Body body = mock(Body.class);
+        when(physicsComponent.getBody()).thenReturn(body);
+        when(body.getWorldCenter()).thenReturn(new Vector2(0f, 0f));
+
+        PlayerActions actions = new PlayerActions();
+        attachEntity(actions);
+        Field physField = PlayerActions.class.getDeclaredField("physicsComponent");
+        physField.setAccessible(true);
+        physField.set(actions, physicsComponent);
+
+        // Configure as double-jump (not ground jump)
+        setField(actions, "dashing", false);
+        setField(actions, "jumpsLeft", 1); // air jump
+        int doubleCost = reflectIntConst(PlayerActions.class, "DOUBLE_JUMP_COST", 10);
+
+        // Case 1: Not enough stamina -> no impulse
+        setField(actions, "stamina", (float) (doubleCost - 1));
+        actions.jump();
+        verify(body, never()).applyLinearImpulse(any(Vector2.class), any(Vector2.class), anyBoolean());
+
+        // Case 2: Enough stamina -> impulse applied and stamina reduced by cost
+        reset(body);
+        setField(actions, "jumpsLeft", 1); // reset for another air jump
+        setField(actions, "stamina", (float) (doubleCost + 5));
+        actions.jump();
+
+        verify(body, times(1)).applyLinearImpulse(any(Vector2.class), nullable(Vector2.class), eq(true));
+        float staminaAfter = reflectFloat(actions, "stamina");
+        assertEquals(doubleCost + 5 - doubleCost, staminaAfter, 1e-4);
+    }
+
+    @Test
+    void infiniteStaminaCheatLocksStaminaAtMax() {
+        PlayerActions actions = new PlayerActions();
+        attachEntity(actions);
+
+        int max = reflectIntConst(PlayerActions.class, "MAX_STAMINA", 100);
+        // Drop stamina, then enable cheat
+        setField(actions, "stamina", 1f);
+        actions.infStamina();
+
+        // Even if we try to "spend", it should succeed and not reduce
+        assertTrue(callTrySpend(actions, 9999));
+        assertEquals(max, (int) reflectFloat(actions, "stamina"));
+
+        // A tick pegs it at MAX too
+        callPrivate(actions, "staminaTick");
+        assertEquals(max, (int) reflectFloat(actions, "stamina"));
+    }
+}


### PR DESCRIPTION
# Description  
Added stamina system for player special movements. Stamina is now drained and regenerated over time depending on the player’s actions, introducing resource management into sprinting and double-jumping.  

Key changes include:  
- Implemented stamina drain while sprinting.  
- Implemented stamina regeneration after a configurable delay when not draining.  
- Added stamina cost for double-jumping, with prevention if insufficient stamina.  
- Added infinite stamina cheat command for debugging/gameplay flexibility.  
- Hooked stamina into the UI (stamina bar).  

This work addresses and closes issue #56.  

## Type of change  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update  

# How Has This Been Tested?  
- Unit tests (`PlayerStaminaTest`) added covering:  
  - Stamina drains when sprinting.  
  - Stamina does not drain when idle.  
  - Stamina regenerates after the configured delay.  
  - Stamina spending fails if insufficient, and succeeds if enough.  
  - Double-jump stamina cost blocks when insufficient, succeeds when sufficient.  
  - Infinite stamina cheat locks stamina at maximum, even when spending or ticking.  
- Manual playtesting:  
  - Verified sprint drains stamina and stops when depleted.  
  - Verified double-jump blocked without stamina.  
  - Verified infinite stamina cheat prevents drain.  

# Checklist:  
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes  
- [x] My changes generate no new warnings  

# Documentation  
- Stamina drains at **15 per second** while sprinting.  
- Stamina regenerates at **10 per second** after an **800ms delay**.  
- Double-jump costs **10 stamina**.  
- Infinite stamina cheat command available for debugging (locks stamina at max).  
- UI stamina bar reflects current stamina.  

# Known Limitations  
- Current cheat code is only toggleable via method call (`infStamina()`), not a bound key yet.  
- Regeneration and drain rates are hardcoded constants (may need balance tweaks).  
- Ground checks for reset of jumps are still pending from earlier movement branch work.  

# Notes to Reviewers  
Please check stamina integration with movement and confirm it works correctly alongside sprinting/dashing/crouching already implemented in the branch. Feedback on balance values (drain/regen rates, double-jump cost) welcome.  