### PR TITLE
Fixed a major bug where the game freeze when gpt enemy dies

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/CombatStatsComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/CombatStatsComponent.java
@@ -165,12 +165,6 @@ public class CombatStatsComponent extends Component {
         return;
     }
     applyDamage(attacker.getBaseAttack());
-
-    if (this.isDead()) {
-      if (ServiceLocator.getGameArea() != null) {
-        ServiceLocator.getGameArea().removeEntity(this.entity);
-      }
-    }
   }
 
   /**

--- a/source/core/src/test/com/csse3200/game/components/CombatStatsComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/CombatStatsComponentTest.java
@@ -108,6 +108,8 @@ class CombatStatsComponentTest {
     ServiceLocator.registerGameArea(area);
     ServiceLocator.registerEntityService(new EntityService());
     area.spawnEntity(victim);
+    // Add a listener to simulate death removal as in the real game
+    victim.getEvents().addListener("death", () -> area.removeEntity(victim));
     victim.getComponent(CombatStatsComponent.class).hit(new CombatStatsComponent(0, 10));
     assertTrue(victim.getComponent(CombatStatsComponent.class).isDead());
     assertEquals(new ArrayList<>(), area.getEntities());


### PR DESCRIPTION
# Description

Fix a bug where the game freeze when an enemy dies

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test in the game directly

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
