### PR TITLE
SonarCloud PRs

### DIFF
--- a/.github/workflows/gradle_release.yaml
+++ b/.github/workflows/gradle_release.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       # Push events on main branch
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build_game:
@@ -37,11 +40,14 @@ jobs:
           cd $GRADLE_DIR
           chmod +x ./gradlew
           ./gradlew --stacktrace build sonarqube --info
-          ls -al
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GRADLE_DIR: 'source' # Modify this to wherever './gradlew' is
+          SONAR_SCANNER_PARAMS: >
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+            -Dsonar.pullrequest.branch=${{ github.head_ref }}
+            -Dsonar.pullrequest.base=${{ github.base_ref }}
 
       - name: Automatic Release # note the path for the files on this one
         uses: marvinpinto/action-automatic-releases@v1.2.1


### PR DESCRIPTION
# Description
Adds SonarCloud checks to PRs to main, allowing students to see code coverage etc. without merging into main.

Fixes / Closes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] This change requires a documentation update

# How Has This Been Tested?

It hasn't and may break current sonarcloud workflow
