### PR TITLE
Upgrade Stations Style Fix

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/WeaponsStatsComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/WeaponsStatsComponent.java
@@ -115,8 +115,6 @@ public class WeaponsStatsComponent extends Component {
         if (this.upgradeStage < maxUpgradeStage) {
             this.upgradeStage++;
             this.baseAttack *= 2;
-        } else {
-            System.out.println("Item already fully upgraded");
         }
     }
 

--- a/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
@@ -88,10 +88,7 @@ public class KeyboardPlayerInputComponent extends InputComponent {
       ItemComponent itemInfo = item.getComponent(ItemComponent.class);
       if (itemInfo.getType() == ItemTypes.RANGED) {
         entity.getEvents().trigger("shoot");
-
-      } else if (itemInfo.getType() == ItemTypes.MELEE) {
-      }
-      else {
+      } else {
         entity.getEvents().trigger("attack");
       }
       return true;


### PR DESCRIPTION
# Description
DISCLAIMER: This PR is adding some extra lines I forgot to commit before merging before :)

This PR will merge the upgrade-stations branch to main. In this branch, a new InteractableStationComponent has been created. This will allow entities to be interacted with when walked by. Currently, the ComputerStation allows for the user to upgrade a weapon to increase its damage.

Fixes / Closes #104 

## Type of change

- [x] InteractableStationFactory - Factory which produces "stations" which the player can interact with to trigger events.
- [x] StationComponent - Component which can be attached to the entity and allows the entity to show text when the player is nearby, and trigger events at the press of a button

# How Has This Been Tested?
- [x] Created JUnit tests to ensure labels were being updated, and the weapon is being upgraded

- [x] General play tests were used to ensure everything was working as expected. You can test by walking up to the bench and pressing E. This will increase weapon damage.

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
