### PR TITLE
Game crash prevention

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/player/PlayerActions.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerActions.java
@@ -362,8 +362,16 @@ public class PlayerActions extends Component {
     InventoryComponent inventory = entity.getComponent(InventoryComponent.class);
     Entity gun = inventory.getCurrItem();
 
+    if (gun == null) {
+      return;
+    }
+
     MagazineComponent mag = gun.getComponent(MagazineComponent.class);
     // Check for cooldown, defaulting to zero if no current weapon
+
+    if (mag == null) {
+      return;
+    }
     float coolDown = weapon.getCoolDown();
     if (this.timeSinceLastAttack < coolDown || mag.reloading()) {
       return;


### PR DESCRIPTION
# Prevents game from crashing due to shooting error

The branch prevents the game from crashing when a null pointer error is experienced when the weapon type is mismatched.