### PR TITLE
Weapons Rotation bug

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/player/ItemPickUpComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/ItemPickUpComponent.java
@@ -113,8 +113,16 @@ public class ItemPickUpComponent extends Component {
     }
 
     /**
-     * Attempts to add an item to the player's inventory.
-     * Clears the target item reference if successful.
+     * Attempts to convert the specified world item into an inventory item
+     * and add it to the player's inventory.
+     * The method checks for an {@link ItemComponent} and its texture path,
+     * maps the texture to a known weapon type weaponFromTexture(String),
+     * and creates a new weapon entity for storage in the inventory.
+     * - If the item is successfully added, the original world entity is disposed
+     * and the active targetItem reference is cleared.
+     * - If the inventory is full, the newly created weapon entity is disposed,
+     * and the world item remains untouched.
+     * - If the texture is missing or unknown, the pickup attempt is ignored.
      *
      * @param item that player is currently touching
      */
@@ -147,6 +155,15 @@ public class ItemPickUpComponent extends Component {
         }
     }
 
+    /**
+     * Resolves a texture path string into a corresponding weapon entity.
+     * This method compares the given texture path against the Weapons
+     * enum configuration and, if matched, creates the appropriate weapon
+     * using the {@link WeaponsFactory}.
+     * @param texture The texture file path associated with the world item.
+     * @return A new {@link Entity} representing the weapon, or null if the
+     * texture does not correspond to any known weapon type.
+     */
     private Entity weaponFromTexture(String texture) {
         for (Weapons w : Weapons.values()) {
             if (texture.equals(w.getConfig().texturePath)) {

--- a/source/core/src/main/com/csse3200/game/components/player/ItemPickUpComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/ItemPickUpComponent.java
@@ -226,8 +226,7 @@ public class ItemPickUpComponent extends Component {
             logger.debug("Drop: no texture info on item; skipping world respawn");
             return;
         }
-        // Attempt to recreate a new item entity from the stored texture
-        //Entity newItem = createItemFromTexture(tex);
+        // Attempt to recreate a new world-pickable item entity from the stored texture
         Entity newItem = WorldPickUpFactory.createPickupFromTexture(tex);
         if (newItem == null) {
             return;

--- a/source/core/src/main/com/csse3200/game/components/player/ItemPickUpComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/ItemPickUpComponent.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.physics.box2d.BodyDef;
 import com.badlogic.gdx.physics.box2d.Fixture;
 import com.csse3200.game.areas.GameArea;
 import com.csse3200.game.components.Component;
+import com.csse3200.game.components.MagazineComponent;
 import com.csse3200.game.components.items.ItemComponent;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.configs.Weapons;
@@ -143,6 +144,11 @@ public class ItemPickUpComponent extends Component {
             logger.warn("Unknown pickup texture {}, ignoring", ic.getTexture());
             return;
         }
+
+        weapon.create();
+        // The two following lines of code were generate by ChatGPT
+        MagazineComponent mag = weapon.getComponent(MagazineComponent.class);
+        if (mag != null) mag.setTimeSinceLastReload(999f);
 
         boolean added = inventory.addItem(weapon);
         if (added) {

--- a/source/core/src/main/com/csse3200/game/components/player/ItemPickUpComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/ItemPickUpComponent.java
@@ -14,6 +14,7 @@ import com.csse3200.game.entities.factories.system.ObstacleFactory;
 import com.csse3200.game.physics.BodyUserData;
 import com.csse3200.game.physics.components.PhysicsComponent;
 import com.csse3200.game.services.ServiceLocator;
+import com.csse3200.game.entities.factories.items.WorldPickUpFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,15 +123,37 @@ public class ItemPickUpComponent extends Component {
             logger.warn("pickUpItem called with null item");
             return;
         }
+        ItemComponent ic = item.getComponent(ItemComponent.class);
+        String tex = (ic != null) ? ic.getTexture() : null;
+        if (tex == null) {
+            logger.warn("Pickup has no ItemComponent/texture");
+            return;
+        }
 
-        boolean added = inventory.addItem(item);
+        Entity weapon = weaponFromTexture(tex);
+        if (weapon == null) {
+            logger.warn("Unknown pickup texture {}, ignoring", ic.getTexture());
+            return;
+        }
+
+        boolean added = inventory.addItem(weapon);
         if (added) {
             item.dispose();
             targetItem = null;
             logger.info("Picked up item and added to inventory");
         } else {
+            weapon.dispose();
             logger.info("Inventory full. Cannot pick up item");
         }
+    }
+
+    private Entity weaponFromTexture(String texture) {
+        for (Weapons w : Weapons.values()) {
+            if (texture.equals(w.getConfig().texturePath)) {
+                return WeaponsFactory.createWeapon(w);
+            }
+        }
+        return null;
     }
 
     /**
@@ -187,7 +210,8 @@ public class ItemPickUpComponent extends Component {
             return;
         }
         // Attempt to recreate a new item entity from the stored texture
-        Entity newItem = createItemFromTexture(tex);
+        //Entity newItem = createItemFromTexture(tex);
+        Entity newItem = WorldPickUpFactory.createPickupFromTexture(tex);
         if (newItem == null) {
             return;
         }

--- a/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
@@ -324,7 +324,7 @@ public class KeyboardPlayerInputComponent extends InputComponent {
         inventory.setCurrItem(weapon);
 //        String name = inventory.getCurrItem().getComponent(class )
 
-        entity.getEvents().trigger("focusItem", selectedSlot);  // Refresh UI & logic
+        entity.getEvents().trigger("focus item", selectedSlot);  // Refresh UI & logic
         System.out.println("Equipped weapon from slot " + selectedSlot);
 
         actions.equipWeapon(weapon);
@@ -346,4 +346,3 @@ public class KeyboardPlayerInputComponent extends InputComponent {
         actions.unequipWeapon();
     }
 }
-

--- a/source/core/src/main/com/csse3200/game/entities/factories/items/WorldPickUpFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/items/WorldPickUpFactory.java
@@ -32,7 +32,7 @@ public class WorldPickUpFactory {
 
     /**
      * Build from texture when dropping
-     * /
+     */
     public static Entity createPickupFromTexture(String texture) {
         for (Weapons w : Weapons.values()) {
             if (texture.equals(w.getConfig().texturePath)) {

--- a/source/core/src/main/com/csse3200/game/entities/factories/items/WorldPickUpFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/items/WorldPickUpFactory.java
@@ -17,7 +17,7 @@ public class WorldPickUpFactory {
         Entity pickup = new Entity()
                 .addComponent(new TextureRenderComponent(tex))
                 .addComponent(new PhysicsComponent())
-                .addComponent(new ColliderComponent())
+                //.addComponent(new ColliderComponent())
                 .addComponent(new HitboxComponent())
                 .addComponent(new ItemComponent());
 

--- a/source/core/src/main/com/csse3200/game/entities/factories/items/WorldPickUpFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/items/WorldPickUpFactory.java
@@ -1,0 +1,44 @@
+package com.csse3200.game.entities.factories.items;
+
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.entities.configs.Weapons;
+import com.csse3200.game.components.items.ItemComponent;
+import com.csse3200.game.entities.configs.ItemTypes;
+import com.csse3200.game.physics.components.PhysicsComponent;
+import com.csse3200.game.physics.components.ColliderComponent;
+import com.csse3200.game.physics.components.HitboxComponent;
+import com.csse3200.game.rendering.TextureRenderComponent;
+import com.badlogic.gdx.physics.box2d.BodyDef;
+
+public class WorldPickUpFactory {
+    public static Entity createWeaponPickup(Weapons type) {
+        String tex = type.getConfig().texturePath;
+
+        Entity pickup = new Entity()
+                .addComponent(new TextureRenderComponent(tex))
+                .addComponent(new PhysicsComponent())
+                .addComponent(new ColliderComponent())
+                .addComponent(new HitboxComponent())
+                .addComponent(new ItemComponent());
+
+        pickup.getComponent(ItemComponent.class).setTexture(tex);
+        pickup.getComponent(ItemComponent.class).setType(
+                type.getConfig().weaponType == com.csse3200.game.entities.configs.ItemTypes.MELEE
+                        ? ItemTypes.MELEE : ItemTypes.RANGED);
+
+        pickup.getComponent(PhysicsComponent.class).setBodyType(BodyDef.BodyType.StaticBody);
+        return pickup;
+    }
+
+    /**
+     * Build from texture when dropping
+     * */
+    public static Entity createPickupFromTexture(String texture) {
+        for (Weapons w : Weapons.values()) {
+            if (texture.equals(w.getConfig().texturePath)) {
+                return createWeaponPickup(w);
+            }
+        }
+        return null;
+    }
+}

--- a/source/core/src/main/com/csse3200/game/entities/factories/items/WorldPickUpFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/items/WorldPickUpFactory.java
@@ -32,7 +32,7 @@ public class WorldPickUpFactory {
 
     /**
      * Build from texture when dropping
-     * */
+     * /
     public static Entity createPickupFromTexture(String texture) {
         for (Weapons w : Weapons.values()) {
             if (texture.equals(w.getConfig().texturePath)) {

--- a/source/core/src/main/com/csse3200/game/entities/spawner/ItemSpawner.java
+++ b/source/core/src/main/com/csse3200/game/entities/spawner/ItemSpawner.java
@@ -5,7 +5,6 @@ import com.badlogic.gdx.physics.box2d.BodyDef;
 import com.csse3200.game.areas.*;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.configs.Weapons;
-import com.csse3200.game.entities.factories.items.WeaponsFactory;
 import com.csse3200.game.entities.factories.items.WorldPickUpFactory;
 import com.csse3200.game.physics.components.PhysicsComponent;
 import org.slf4j.Logger;
@@ -103,12 +102,13 @@ public class ItemSpawner {
 
 
     /**
-     * Creates an world pickable item entity based on the provided type
-     * This method currently supports weapon types defined in the Weapons enum
-     * Additional item types like consumables, perishables, etc. can be added accordingly
+     * Creates a new world-pickable item entity from the given type string.
+     * If the type matches a {@link Weapons} enum constant, a corresponding
+     * weapon pickup entity is created via {@link WorldPickUpFactory}.
      *
      * @param type which is the type of item to be created
-     * @return the created item entity or null if the type is unknown
+     * @return A new {@link Entity} representing the item, or {@code null} if the
+     * type does not match any known item.
      */
     protected Entity makeItem(String type) {
         try {

--- a/source/core/src/main/com/csse3200/game/entities/spawner/ItemSpawner.java
+++ b/source/core/src/main/com/csse3200/game/entities/spawner/ItemSpawner.java
@@ -6,6 +6,7 @@ import com.csse3200.game.areas.*;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.configs.Weapons;
 import com.csse3200.game.entities.factories.items.WeaponsFactory;
+import com.csse3200.game.entities.factories.items.WorldPickUpFactory;
 import com.csse3200.game.physics.components.PhysicsComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +103,7 @@ public class ItemSpawner {
 
 
     /**
-     * Creates an item entity based on the provided type
+     * Creates an world pickable item entity based on the provided type
      * This method currently supports weapon types defined in the Weapons enum
      * Additional item types like consumables, perishables, etc. can be added accordingly
      *
@@ -112,9 +113,8 @@ public class ItemSpawner {
     protected Entity makeItem(String type) {
         try {
             Weapons weapon = Weapons.valueOf(type.toUpperCase());
-            return WeaponsFactory.createWeapon(weapon);
+            return WorldPickUpFactory.createWeaponPickup(weapon);
         } catch (IllegalArgumentException e) {
-            //try consumables/perishables(other items)
             switch (type.toLowerCase()) {
                 default:
                     logger.warn("Unknown item type: {}", type);

--- a/source/core/src/test/com/csse3200/game/components/player/ItemPickUpComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/ItemPickUpComponentTest.java
@@ -4,7 +4,6 @@ import com.csse3200.game.components.items.ItemComponent;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.EntityService;
 import com.csse3200.game.extensions.GameExtension;
-import com.csse3200.game.physics.PhysicsEngine;
 import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,14 +12,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.Mockito.*;
-import static org.mockito.ArgumentMatchers.*;
-
 import com.badlogic.gdx.graphics.Texture;
 import com.csse3200.game.physics.PhysicsService;
-
-import java.lang.reflect.Field;
-
 import static org.junit.jupiter.api.Assertions.*;
+import java.lang.reflect.Field;
 
 /**
  * Unit tests for ItemPickUpComponent focusing on event-driven behaviour:
@@ -66,8 +61,11 @@ class ItemPickUpComponentTest {
         pickup = new ItemPickUpComponent(inventory);
         ServiceLocator.registerEntityService(new EntityService());
 
+        // Create a mock ResourceService
         ResourceService rs = mock(ResourceService.class);
+        // Make getAsset to always return a mock Texture when asked for any texture path
         when(rs.getAsset(anyString(), eq(Texture.class))).thenReturn(mock(Texture.class));
+        // Register the mocked ResourceService and PhysicsService
         ServiceLocator.registerResourceService(rs);
         ServiceLocator.registerPhysicsService(mock(PhysicsService.class));
 

--- a/source/core/src/test/com/csse3200/game/components/player/ItemPickUpComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/player/ItemPickUpComponentTest.java
@@ -1,9 +1,12 @@
 package com.csse3200.game.components.player;
 
+import com.badlogic.gdx.physics.box2d.Body;
 import com.csse3200.game.components.items.ItemComponent;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.EntityService;
 import com.csse3200.game.extensions.GameExtension;
+import com.csse3200.game.physics.PhysicsEngine;
+import com.csse3200.game.rendering.RenderService;
 import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +70,15 @@ class ItemPickUpComponentTest {
         when(rs.getAsset(anyString(), eq(Texture.class))).thenReturn(mock(Texture.class));
         // Register the mocked ResourceService and PhysicsService
         ServiceLocator.registerResourceService(rs);
-        ServiceLocator.registerPhysicsService(mock(PhysicsService.class));
+        RenderService renderService = mock(RenderService.class);
+        ServiceLocator.registerRenderService(renderService);
+
+        PhysicsService physicsService = mock(PhysicsService.class);
+        PhysicsEngine physicsEngine = mock(PhysicsEngine.class);
+        when(physicsService.getPhysics()).thenReturn(physicsEngine);
+        when(physicsEngine.createBody(any())).thenReturn(mock(Body.class));
+        ServiceLocator.registerPhysicsService(physicsService);
+        //ServiceLocator.registerPhysicsService(mock(PhysicsService.class));
 
         player = new Entity()
                 .addComponent(inventory)


### PR DESCRIPTION
# Description

This PR fixes the bug where all weapons placed in the world rotate with the mouse cursor, even when they are just lying on the ground. There is now a clear separation between:

- World pickups: non-rotating textures used only for being seen and picked up.
- Inventory/equipped weapons: fully featured weapon entities (with rotation/behaviour) created only when a pickup is collected.

Fixes / Closes #210 

## Type of change

### ItemPickUpComponent

- **pickUpItem()**: reads the pickup’s ItemComponent.texture, creates a proper weapon via `WeaponsFactory` (weaponFromTexture()), adds the weapon to the inventory, and disposes the world pickup shell.
- **onDropFocused()**: removes the focused inventory weapon and respawns a world pickup shell using `WorldPickUpFactory.createPickupFromTexture(tex)`. 

### ItemSpawner

- **ItemSpawner.makeItem()** now creates world pickup shells via `WorldPickUpFactory.createWeaponPickup(Weapons)` so spawned map items no longer rotate with the mouse.


- [x] Bug fix (non-breaking change which fixes an issue)

- [x] This change needs documentation updates in wiki

# How Has This Been Tested?

### Unit tests
`ItemPickUpComponentTest.pickUpAddsItemAndClearsTarget`
- Uses ResourceService (textures) and PhysicsService.
- Creates a world pickup shell with ItemComponent.texture = images/pistol.png.
- Triggers "pick up" → inventory receives a new weapon entity (not the shell), and targetItem clears.

### Manual testing

1. Start a map with items on the ground.
2. Move the mouse around: world items do not rotate.
3. Walk to an item and press E:
4. Item disappears from world.
5. Inventory gains the weapon (now rotates when actually equipped/used).
6. Press R on a focused slot:
7. Inventory item is removed.
8. A non-rotating pickup shell appears slightly offset at the player’s feet.

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
