### PR TITLE
Adding Boss Rooms

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/FlyingBossRoom.java
+++ b/source/core/src/main/com/csse3200/game/areas/FlyingBossRoom.java
@@ -1,0 +1,163 @@
+package com.csse3200.game.areas;
+
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.math.GridPoint2;
+import com.csse3200.game.areas.terrain.TerrainFactory;
+import com.csse3200.game.areas.terrain.TerrainFactory.TerrainType;
+import com.csse3200.game.components.CameraComponent;
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.entities.configs.ItemSpawnConfig;
+import com.csse3200.game.entities.factories.characters.BossFactory;
+import com.csse3200.game.entities.factories.system.ObstacleFactory;
+import com.csse3200.game.entities.spawner.ItemSpawner;
+import com.csse3200.game.entities.factories.characters.PlayerFactory;
+import com.csse3200.game.services.ServiceLocator;
+import com.csse3200.game.components.gamearea.GameAreaDisplay;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is the room that holds the Flying Boss.
+ * The boss is a flying enemy that spawns at the top of the map and
+ * shoots projectiles at the player.
+ * 
+ * There are two platforms that can possibly server as cover as well as a floor
+ * at the bottom
+ */
+public class FlyingBossRoom extends GameArea {
+    private static final Logger logger = LoggerFactory.getLogger(FlyingBossRoom.class);
+
+    private static final GridPoint2 PLAYER_SPAWN = new GridPoint2(3, 10);
+
+    private static final float WALL_WIDTH = 0.1f;
+
+    private Entity player;
+
+    /**
+     * Creates a new FlyingBossRoom for the room where the flying boss spawns.
+     * 
+     * @param terrainFactory  TerrainFactory used to create the terrain for the
+     *                        GameArea (required).
+     * @param cameraComponent Camera helper supplying an OrthographicCamera
+     *                        (optional but used here).
+     * @requires terrainFactory not null
+     */
+    public FlyingBossRoom(TerrainFactory terrainFactory, CameraComponent cameraComponent) {
+        super(terrainFactory, cameraComponent);
+    }
+
+    /**
+     * Creates the room by:
+     * - spawning doors
+     * - displaying the UI
+     * - spawns player
+     * - spawns platforms
+     * - spanws walls
+     * - spawns the flying boss
+     * - spawns items
+     */
+    @Override
+    public void create() {
+        ServiceLocator.registerGameArea(this);
+
+        GenericLayout.ensureGenericAssets(this);
+        GenericLayout.setupTerrainWithOverlay(this, terrainFactory, TerrainType.SERVER_ROOM,
+                new Color(0.10f, 0.12f, 0.10f, 0.24f));
+
+        spawnBordersAndDoors();
+        displayUI();
+
+        player = spawnPlayer();
+
+        spawnPlatforms();
+        spawnBigWall();
+
+        spawnFlyingBoss();
+        spawnObjectDoors(new GridPoint2(0, 6), new GridPoint2(28, 6));
+
+        ItemSpawner itemSpawner = new ItemSpawner(this);
+        itemSpawner.spawnItems(ItemSpawnConfig.bossmap());
+
+        spawnFloor();
+    }
+
+    private void displayUI() {
+        Entity ui = new Entity();
+        ui.addComponent(new GameAreaDisplay("Flying Boss Room"))
+                .addComponent(new com.csse3200.game.components.gamearea.FloorLabelDisplay("Flying Boss Room"));
+        spawnEntity(ui);
+    }
+
+    private void spawnPlatforms() {
+        Entity platform1 = ObstacleFactory.createThinFloor();
+        GridPoint2 platform1Pos = new GridPoint2(4, 10);
+        spawnEntityAt(platform1, platform1Pos, false, false);
+
+        Entity platform3 = ObstacleFactory.createThinFloor();
+        GridPoint2 platform3Pos = new GridPoint2(22, 10);
+        spawnEntityAt(platform3, platform3Pos, false, false);
+    }
+
+    private Entity spawnPlayer() {
+        Entity newPlayer = PlayerFactory.createPlayer();
+        spawnEntityAt(newPlayer, PLAYER_SPAWN, true, true);
+        return newPlayer;
+    }
+
+    private void spawnFlyingBoss() {
+        GridPoint2 pos = new GridPoint2(15, 20);
+
+        Entity flyingBoss = BossFactory.createBoss2(player);
+        spawnEntityAt(flyingBoss, pos, true, true);
+    }
+
+    /**
+     * Adds a very tall thick-floor as a background wall/divider.
+     */
+    private void spawnBigWall() {
+        GridPoint2 wallSpawn = new GridPoint2(-14, 0);
+        Entity bigWall = ObstacleFactory.createBigThickFloor();
+        spawnEntityAt(bigWall, wallSpawn, true, false);
+    }
+
+    /**
+     * Spawns the borders and doors of the room.
+     * Different to genericLayout as the right door is up high
+     * at the third platform level.
+     */
+    private void spawnBordersAndDoors() {
+        if (cameraComponent == null)
+            return;
+        Bounds b = getCameraBounds(cameraComponent);
+        addSolidWallLeft(b, WALL_WIDTH);
+        float leftDoorHeight = Math.max(1f, b.viewHeight() * 0.2f);
+        float leftDoorY = b.bottomY();
+        Entity leftDoor = ObstacleFactory.createDoorTrigger(WALL_WIDTH, leftDoorHeight);
+        leftDoor.setPosition(b.leftX() + 0.001f, leftDoorY);
+        leftDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadResearch));
+        spawnEntity(leftDoor);
+
+        addSolidWallRight(b, WALL_WIDTH);
+
+        float rightDoorHeight = Math.max(1f, b.viewHeight() * 0.2f);
+        float rightDoorY = b.bottomY();
+        Entity rightDoor = ObstacleFactory.createDoorTrigger(WALL_WIDTH, rightDoorHeight);
+        rightDoor.setPosition(b.rightX() - WALL_WIDTH - 0.001f, rightDoorY);
+        rightDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadShipping));
+        spawnEntity(rightDoor);
+    }
+
+    public Entity getPlayer() {
+        return player;
+    }
+
+    public void loadShipping() {
+        clearAndLoad(() -> new ShippingGameArea(terrainFactory, cameraComponent));
+    }
+
+    public void loadResearch() {
+        clearAndLoad(() -> new ResearchGameArea(terrainFactory, cameraComponent));
+    }
+}

--- a/source/core/src/main/com/csse3200/game/areas/MovingBossRoom.java
+++ b/source/core/src/main/com/csse3200/game/areas/MovingBossRoom.java
@@ -1,0 +1,148 @@
+package com.csse3200.game.areas;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.math.GridPoint2;
+import com.csse3200.game.areas.terrain.TerrainFactory;
+import com.csse3200.game.areas.terrain.TerrainFactory.TerrainType;
+import com.csse3200.game.components.CameraComponent;
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.entities.configs.ItemSpawnConfig;
+import com.csse3200.game.entities.factories.characters.BossFactory;
+import com.csse3200.game.entities.factories.system.ObstacleFactory;
+import com.csse3200.game.entities.spawner.ItemSpawner;
+import com.csse3200.game.entities.factories.characters.PlayerFactory;
+import com.csse3200.game.services.ServiceLocator;
+import com.csse3200.game.components.gamearea.GameAreaDisplay;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is the room that holds the Ground Moving Boss Boss.
+ * This boss is a small robot that moves towards the player and attacks
+ * 
+ * Room is empty except for boss and player
+ */
+public class MovingBossRoom extends GameArea {
+    private static final Logger logger = LoggerFactory.getLogger(MovingBossRoom.class);
+
+    private static final GridPoint2 PLAYER_SPAWN = new GridPoint2(3, 10);
+
+    private static final float WALL_WIDTH = 0.1f;
+
+    private Entity player;
+
+    /**
+     * Creates a new MovingBossRoom for the room where the flying boss spawns.
+     * 
+     * @param terrainFactory  TerrainFactory used to create the terrain for the
+     *                        GameArea (required).
+     * @param cameraComponent Camera helper supplying an OrthographicCamera
+     *                        (optional but used here).
+     * @requires terrainFactory not null
+     */
+    public MovingBossRoom(TerrainFactory terrainFactory, CameraComponent cameraComponent) {
+        super(terrainFactory, cameraComponent);
+    }
+
+    /**
+     * Creates the room by:
+     * - loading assest
+     * - displaying the UI
+     * - spawning terrain (without door triggers)
+     * - spawn player and rifle
+     * - spawns static boss
+     * - spawns floors
+     */
+    @Override
+    public void create() {
+        ServiceLocator.registerGameArea(this);
+
+        GenericLayout.ensureGenericAssets(this);
+        GenericLayout.setupTerrainWithOverlay(this, terrainFactory, TerrainType.SERVER_ROOM,
+                new Color(0.10f, 0.12f, 0.10f, 0.24f));
+
+        spawnBordersAndDoors();
+        displayUI();
+
+        player = spawnPlayer();
+
+        spawnBigWall();
+
+        spawnBoss();
+        spawnObjectDoors(new GridPoint2(0, 6), new GridPoint2(28, 6));
+
+        ItemSpawner itemSpawner = new ItemSpawner(this);
+        itemSpawner.spawnItems(ItemSpawnConfig.bossmap());
+
+        spawnFloor();
+    }
+
+    private void displayUI() {
+        Entity ui = new Entity();
+        ui.addComponent(new GameAreaDisplay("Moving Boss Room"))
+                .addComponent(new com.csse3200.game.components.gamearea.FloorLabelDisplay("Moving Boss Room"));
+        spawnEntity(ui);
+    }
+
+    private Entity spawnPlayer() {
+        Entity newPlayer = PlayerFactory.createPlayer();
+        spawnEntityAt(newPlayer, PLAYER_SPAWN, true, true);
+        return newPlayer;
+    }
+
+    private void spawnBoss() {
+        GridPoint2 pos = new GridPoint2(15, 20);
+
+        Entity boss = BossFactory.createRobot(player);
+        spawnEntityAt(boss, pos, true, true);
+    }
+
+    /**
+     * Adds a very tall thick-floor as a background wall/divider.
+     */
+    private void spawnBigWall() {
+        GridPoint2 wallSpawn = new GridPoint2(-14, 0);
+        Entity bigWall = ObstacleFactory.createBigThickFloor();
+        spawnEntityAt(bigWall, wallSpawn, true, false);
+    }
+
+    /**
+     * Spawns the borders and doors of the room.
+     * Different to genericLayout as the right door is up high
+     * at the third platform level.
+     */
+    private void spawnBordersAndDoors() {
+        if (cameraComponent == null)
+            return;
+        Bounds b = getCameraBounds(cameraComponent);
+        addSolidWallLeft(b, WALL_WIDTH);
+        float leftDoorHeight = Math.max(1f, b.viewHeight() * 0.2f);
+        float leftDoorY = b.bottomY();
+        Entity leftDoor = ObstacleFactory.createDoorTrigger(WALL_WIDTH, leftDoorHeight);
+        leftDoor.setPosition(b.leftX() + 0.001f, leftDoorY);
+        leftDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadSecurity));
+        spawnEntity(leftDoor);
+
+        addSolidWallRight(b, WALL_WIDTH);
+
+        float rightDoorHeight = Math.max(1f, b.viewHeight() * 0.2f);
+        float rightDoorY = b.bottomY();
+        Entity rightDoor = ObstacleFactory.createDoorTrigger(WALL_WIDTH, rightDoorHeight);
+        rightDoor.setPosition(b.rightX() - WALL_WIDTH - 0.001f, rightDoorY);
+        rightDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadOffice));
+        spawnEntity(rightDoor);
+    }
+
+    public Entity getPlayer() {
+        return player;
+    }
+
+    public void loadSecurity() {
+        clearAndLoad(() -> new SecurityGameArea(terrainFactory, cameraComponent));
+    }
+
+    public void loadOffice() {
+        clearAndLoad(() -> new OfficeGameArea(terrainFactory, cameraComponent));
+    }
+}

--- a/source/core/src/main/com/csse3200/game/areas/OfficeGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/OfficeGameArea.java
@@ -45,7 +45,7 @@ public class OfficeGameArea extends GameArea {
     private void spawnBordersAndDoors() {
         Bounds b = getCameraBounds(cameraComponent);
 
-        addVerticalDoorLeft(b, WALL_WIDTH, this::loadSecurity);
+        addVerticalDoorLeft(b, WALL_WIDTH, this::loadMovingBossRoom);
         // Raise the right door higher than center
         addSolidWallTop(b, WALL_WIDTH);
         addSolidWallBottom(b, WALL_WIDTH);
@@ -128,9 +128,9 @@ public class OfficeGameArea extends GameArea {
         }
     }
 
-    private void loadSecurity() {
+    private void loadMovingBossRoom() {
         roomNumber--;
-        clearAndLoad(() -> new SecurityGameArea(terrainFactory, cameraComponent));
+        clearAndLoad(() -> new MovingBossRoom(terrainFactory, cameraComponent));
     }
 
     private void loadElevator() {

--- a/source/core/src/main/com/csse3200/game/areas/ResearchGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/ResearchGameArea.java
@@ -60,7 +60,7 @@ public class ResearchGameArea extends GameArea {
         float rightDoorY = b.topY() - rightDoorHeight;
         Entity rightDoor = ObstacleFactory.createDoorTrigger(WALL_WIDTH, rightDoorHeight);
         rightDoor.setPosition(b.rightX() - WALL_WIDTH - 0.001f, rightDoorY);
-        rightDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadShipping));
+        rightDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadFlyingBossRoom));
         spawnEntity(rightDoor);
     }
 
@@ -146,8 +146,8 @@ public class ResearchGameArea extends GameArea {
         clearAndLoad(() -> new ElevatorGameArea(terrainFactory, cameraComponent));
     }
 
-    private void loadShipping() {
-        clearAndLoad(() -> new ShippingGameArea(terrainFactory, cameraComponent));
+    private void loadFlyingBossRoom() {
+        clearAndLoad(() -> new FlyingBossRoom(terrainFactory, cameraComponent));
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/areas/SecurityGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/SecurityGameArea.java
@@ -60,7 +60,7 @@ public class SecurityGameArea extends GameArea {
         float rightDoorY = b.topY() - rightDoorHeight;
         Entity rightDoor = ObstacleFactory.createDoorTrigger(WALL_WIDTH, rightDoorHeight);
         rightDoor.setPosition(b.rightX() - WALL_WIDTH - 0.001f, rightDoorY);
-        rightDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadOffice));
+        rightDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadMovingBossRoom));
         spawnEntity(rightDoor);
     }
 
@@ -146,9 +146,9 @@ public class SecurityGameArea extends GameArea {
         clearAndLoad(() -> new MainHall(terrainFactory, cameraComponent));
     }
 
-    private void loadOffice() {
+    private void loadMovingBossRoom() {
         roomNumber++;
-        clearAndLoad(() -> new OfficeGameArea(terrainFactory, cameraComponent));
+        clearAndLoad(() -> new MovingBossRoom(terrainFactory, cameraComponent));
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/areas/ServerGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/ServerGameArea.java
@@ -63,7 +63,7 @@ public class ServerGameArea extends GameArea {
         spawnCratesAndRailing();
         spawnSpawnPads();
         spawnBordersAndDoors();
-        spawnObjectDoors(new GridPoint2(0, 6), new GridPoint2(28, 21));
+        spawnObjectDoors(new GridPoint2(0, 7), new GridPoint2(28, 21));
 
         spawnFloor();
 

--- a/source/core/src/main/com/csse3200/game/areas/ShippingGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/ShippingGameArea.java
@@ -120,7 +120,7 @@ public class ShippingGameArea extends GameArea {
         float leftDoorY = b.bottomY();
         Entity leftDoor = ObstacleFactory.createDoorTrigger(WALL_WIDTH, leftDoorHeight);
         leftDoor.setPosition(b.leftX() + 0.001f, leftDoorY);
-        leftDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadResearch));
+        leftDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadFlyingBossRoom));
         spawnEntity(leftDoor);
 
         addSolidWallRight(b, WALL_WIDTH);
@@ -173,8 +173,8 @@ public class ShippingGameArea extends GameArea {
     /**
      * Clears the game area and loads the previous section (Research).
      */
-    private void loadResearch() {
-        clearAndLoad(() -> new ResearchGameArea(terrainFactory, cameraComponent));
+    private void loadFlyingBossRoom() {
+        clearAndLoad(() -> new FlyingBossRoom(terrainFactory, cameraComponent));
     }
 
     /**

--- a/source/core/src/main/com/csse3200/game/areas/StaticBossRoom.java
+++ b/source/core/src/main/com/csse3200/game/areas/StaticBossRoom.java
@@ -1,0 +1,137 @@
+package com.csse3200.game.areas;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.math.GridPoint2;
+import com.csse3200.game.areas.terrain.TerrainFactory;
+import com.csse3200.game.areas.terrain.TerrainFactory.TerrainType;
+import com.csse3200.game.components.CameraComponent;
+import com.csse3200.game.entities.Entity;
+import com.csse3200.game.entities.configs.ItemSpawnConfig;
+import com.csse3200.game.entities.factories.characters.BossFactory;
+import com.csse3200.game.entities.factories.system.ObstacleFactory;
+import com.csse3200.game.entities.spawner.ItemSpawner;
+import com.csse3200.game.entities.factories.characters.PlayerFactory;
+import com.csse3200.game.services.ServiceLocator;
+import com.csse3200.game.components.gamearea.GameAreaDisplay;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is the room that holds the static Boss.
+ * The boss is a static enemy that spawns on the floor and
+ * shoots projectiles outwards from itself. Most
+ * challenging boss.
+ * 
+ * Room is empty except for boss and player
+ */
+public class StaticBossRoom extends GameArea {
+    private static final Logger logger = LoggerFactory.getLogger(StaticBossRoom.class);
+
+    private static final GridPoint2 PLAYER_SPAWN = new GridPoint2(3, 10);
+
+    private static final float WALL_WIDTH = 0.1f;
+
+    private Entity player;
+
+    /**
+     * Creates a new StaticBossRoom for the room where the static boss spawns.
+     * 
+     * @param terrainFactory  TerrainFactory used to create the terrain for the
+     *                        GameArea (required).
+     * @param cameraComponent Camera helper supplying an OrthographicCamera
+     *                        (optional but used here).
+     * @requires terrainFactory not null
+     */
+    public StaticBossRoom(TerrainFactory terrainFactory, CameraComponent cameraComponent) {
+        super(terrainFactory, cameraComponent);
+    }
+
+    /**
+     * Creates the room by:
+     * - loading assest
+     * - displaying the UI
+     * - spawning terrain (without door triggers)
+     * - spawn player and rifle
+     * - spawns static boss
+     * - spawns floors
+     */
+    @Override
+    public void create() {
+        ServiceLocator.registerGameArea(this);
+
+        GenericLayout.ensureGenericAssets(this);
+        GenericLayout.setupTerrainWithOverlay(this, terrainFactory, TerrainType.SERVER_ROOM,
+                new Color(0.10f, 0.12f, 0.10f, 0.24f));
+
+        spawnBordersAndDoors();
+        displayUI();
+
+        player = spawnPlayer();
+
+        spawnBigWall();
+
+        spawnBoss();
+        spawnObjectDoors(new GridPoint2(0, 6), new GridPoint2(28, 6));
+
+        ItemSpawner itemSpawner = new ItemSpawner(this);
+        itemSpawner.spawnItems(ItemSpawnConfig.bossmap());
+
+        spawnFloor();
+    }
+
+    private void displayUI() {
+        Entity ui = new Entity();
+        ui.addComponent(new GameAreaDisplay("Static Boss Room"))
+                .addComponent(new com.csse3200.game.components.gamearea.FloorLabelDisplay("Static Boss Room"));
+        spawnEntity(ui);
+    }
+
+    private Entity spawnPlayer() {
+        Entity newPlayer = PlayerFactory.createPlayer();
+        spawnEntityAt(newPlayer, PLAYER_SPAWN, true, true);
+        return newPlayer;
+    }
+
+    private void spawnBoss() {
+        GridPoint2 pos = new GridPoint2(25, 12);
+
+        Entity boss = BossFactory.createBoss3(player);
+        spawnEntityAt(boss, pos, true, true);
+    }
+
+    /**
+     * Adds a very tall thick-floor as a background wall/divider.
+     */
+    private void spawnBigWall() {
+        GridPoint2 wallSpawn = new GridPoint2(-14, 0);
+        Entity bigWall = ObstacleFactory.createBigThickFloor();
+        spawnEntityAt(bigWall, wallSpawn, true, false);
+    }
+
+    /**
+     * Spawns the borders and doors of the room.
+     */
+    private void spawnBordersAndDoors() {
+        if (cameraComponent == null)
+            return;
+        Bounds b = getCameraBounds(cameraComponent);
+        addSolidWallLeft(b, WALL_WIDTH);
+        float leftDoorHeight = Math.max(1f, b.viewHeight() * 0.2f);
+        float leftDoorY = b.bottomY();
+        Entity leftDoor = ObstacleFactory.createDoorTrigger(WALL_WIDTH, leftDoorHeight);
+        leftDoor.setPosition(b.leftX() + 0.001f, leftDoorY);
+        leftDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadTunnel));
+        spawnEntity(leftDoor);
+
+        addSolidWallRight(b, WALL_WIDTH);
+    }
+
+    public Entity getPlayer() {
+        return player;
+    }
+
+    public void loadTunnel() {
+        clearAndLoad(() -> new TunnelGameArea(terrainFactory, cameraComponent));
+    }
+}

--- a/source/core/src/main/com/csse3200/game/areas/TunnelGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/TunnelGameArea.java
@@ -48,7 +48,7 @@ public class TunnelGameArea extends GameArea {
         spawnPlatforms();
         spawnSpawnPads();
         spawnGrokDroids();
-        spawnObjectDoors();
+        spawnObjectDoors(new GridPoint2(0, 7), new GridPoint2(28, 7));
 
         spawnFloor();
 
@@ -64,10 +64,25 @@ public class TunnelGameArea extends GameArea {
      * Spawns the borders and doors of the room.
      */
     private void spawnBordersAndDoors() {
+        if (cameraComponent == null)
+            return;
         Bounds b = getCameraBounds(cameraComponent);
-        addVerticalDoorLeft(b, WALL_WIDTH, this::loadServer);
-        addSolidWallTop(b, WALL_WIDTH);
-        addSolidWallBottom(b, WALL_WIDTH);
+        addSolidWallLeft(b, WALL_WIDTH);
+        float leftDoorHeight = Math.max(1f, b.viewHeight() * 0.2f);
+        float leftDoorY = b.bottomY();
+        Entity leftDoor = ObstacleFactory.createDoorTrigger(WALL_WIDTH, leftDoorHeight);
+        leftDoor.setPosition(b.leftX() + 0.001f, leftDoorY);
+        leftDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadServer));
+        spawnEntity(leftDoor);
+
+        addSolidWallRight(b, WALL_WIDTH);
+
+        float rightDoorHeight = Math.max(1f, b.viewHeight() * 0.2f);
+        float rightDoorY = b.bottomY();
+        Entity rightDoor = ObstacleFactory.createDoorTrigger(WALL_WIDTH, rightDoorHeight);
+        rightDoor.setPosition(b.rightX() - WALL_WIDTH - 0.001f, rightDoorY);
+        rightDoor.addComponent(new com.csse3200.game.components.DoorComponent(this::loadBossRoom));
+        spawnEntity(rightDoor);
     }
 
     /**
@@ -132,18 +147,12 @@ public class TunnelGameArea extends GameArea {
         spawnEntityAt(grok2, grok2Pos, true, false);
     }
 
-    /**
-     * Spawn entity door at the bottom left, and no door to the right
-     * as this is the last room (currently).
-     */
-    private void spawnObjectDoors() {
-        Entity leftDoor = ObstacleFactory.createDoor();
-        GridPoint2 leftDoorSpawn = new GridPoint2(0, 7);
-        spawnEntityAt(leftDoor, leftDoorSpawn, false, false);
-    }
-
     private void loadServer() {
         clearAndLoad(() -> new ServerGameArea(terrainFactory, cameraComponent));
+    }
+
+    private void loadBossRoom() {
+        clearAndLoad(() -> new StaticBossRoom(terrainFactory, cameraComponent));
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/entities/configs/ItemSpawnConfig.java
+++ b/source/core/src/main/com/csse3200/game/entities/configs/ItemSpawnConfig.java
@@ -139,6 +139,19 @@ public class ItemSpawnConfig {
 
         return config;
     }
+
+    /**
+     * Boss room Spawning. Spawns a rifle next to the player
+     */
+    public static Map<String, List<ItemSpawner.ItemSpawnInfo>> bossmap() {
+        Map<String, List<ItemSpawner.ItemSpawnInfo>> config = new HashMap<>();
+
+        config.put(Weapons.RIFLE.name(), List.of(
+                new ItemSpawner.ItemSpawnInfo(new GridPoint2(5, 7), 1)
+        ));
+
+        return config;
+    }
     //  for a new map just add more methods
 
 }

--- a/source/core/src/main/com/csse3200/game/entities/spawner/ItemSpawner.java
+++ b/source/core/src/main/com/csse3200/game/entities/spawner/ItemSpawner.java
@@ -97,6 +97,12 @@ public class ItemSpawner {
             shippingGameArea.spawnItem(item, position);
         } else if (gameArea instanceof StorageGameArea storageGameArea) {
             storageGameArea.spawnItem(item, position);
+        } else if (gameArea instanceof StaticBossRoom staticBossRoom) {
+            staticBossRoom.spawnItem(item, position);
+        } else if (gameArea instanceof MovingBossRoom movingBossRoom) {
+            movingBossRoom.spawnItem(item, position);
+        } else if (gameArea instanceof FlyingBossRoom flyingBossRoom) {
+            flyingBossRoom.spawnItem(item, position);
         }
     }
 

--- a/source/core/src/test/com/csse3200/game/areas/OfficeAreaTest.java
+++ b/source/core/src/test/com/csse3200/game/areas/OfficeAreaTest.java
@@ -56,12 +56,12 @@ class OfficeAreaTest {
     void testTraversals() throws Exception {
         doNothing().when(officeGameArea).clearAndLoad(any());
 
-        var method = OfficeGameArea.class.getDeclaredMethod("loadSecurity");
+        var method = OfficeGameArea.class.getDeclaredMethod("loadMovingBossRoom");
         method.setAccessible(true);
         method.invoke(officeGameArea);
 
         verify(officeGameArea).clearAndLoad(argThat(supplier -> {
-            return supplier.get() instanceof SecurityGameArea;
+            return supplier.get() instanceof MovingBossRoom;
         }));
 
         var method2 = OfficeGameArea.class.getDeclaredMethod("loadElevator");

--- a/source/core/src/test/com/csse3200/game/areas/ResearchAreaTest.java
+++ b/source/core/src/test/com/csse3200/game/areas/ResearchAreaTest.java
@@ -64,12 +64,12 @@ class ResearchAreaTest {
             return supplier.get() instanceof ElevatorGameArea;
         }));
 
-        var method2 = ResearchGameArea.class.getDeclaredMethod("loadShipping");
+        var method2 = ResearchGameArea.class.getDeclaredMethod("loadFlyingBossRoom");
         method2.setAccessible(true);
         method2.invoke(researchGameArea);
 
         verify(researchGameArea).clearAndLoad(argThat(supplier -> {
-            return supplier.get() instanceof ShippingGameArea;
+            return supplier.get() instanceof FlyingBossRoom;
         }));
     }
 }

--- a/source/core/src/test/com/csse3200/game/areas/SecurityAreaTest.java
+++ b/source/core/src/test/com/csse3200/game/areas/SecurityAreaTest.java
@@ -64,12 +64,12 @@ class SecurityAreaTest {
             return supplier.get() instanceof MainHall;
         }));
 
-        var method2 = SecurityGameArea.class.getDeclaredMethod("loadOffice");
+        var method2 = SecurityGameArea.class.getDeclaredMethod("loadMovingBossRoom");
         method2.setAccessible(true);
         method2.invoke(securityGameArea);
 
         verify(securityGameArea).clearAndLoad(argThat(supplier -> {
-            return supplier.get() instanceof OfficeGameArea;
+            return supplier.get() instanceof MovingBossRoom;
         }));
     }
 }

--- a/source/core/src/test/com/csse3200/game/areas/ShippingAreaTest.java
+++ b/source/core/src/test/com/csse3200/game/areas/ShippingAreaTest.java
@@ -56,12 +56,12 @@ class ShippingAreaTest {
     void testTraversals() throws Exception {
         doNothing().when(shippingGameArea).clearAndLoad(any());
 
-        var method = ShippingGameArea.class.getDeclaredMethod("loadResearch");
+        var method = ShippingGameArea.class.getDeclaredMethod("loadFlyingBossRoom");
         method.setAccessible(true);
         method.invoke(shippingGameArea);
 
         verify(shippingGameArea).clearAndLoad(argThat(supplier -> {
-            return supplier.get() instanceof ResearchGameArea;
+            return supplier.get() instanceof FlyingBossRoom;
         }));
 
         var method2 = ShippingGameArea.class.getDeclaredMethod("loadStorage");


### PR DESCRIPTION
# Description

This PR adds in boss rooms into the map. Each of the 3 bosses are now implemented with their own room with each room spawning a rifle next to the player:

- Moving Ground Boss (robot boss) is now in room 5, after Security and before Office. It has the name ```MovingBossRoom.java```.
- Flying Boss is now in room 9, after Research and before Shipping. It has the name ```FlyingBossRoom.java```
- Static Ground Boss is now room 13, and is the last room in the map so far, extending after the tunnel room. It has the name ```StaticBossRoom.java```

Closes #149 

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

No unit tests have been made on the specific room, as to leave room for expansions / changes in the room. However, there are still a couple tests:
- [ ] Traversing has been tested from the rooms immediately prior and after each boss room, so that they are accessed correctly.

# Checklist:

- [ ] My code follows the style guidelines of this project

- [ ] I have performed a self-review of my code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
