### PR TITLE
Timer

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/maingame/MainGameDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/maingame/MainGameDisplay.java
@@ -2,9 +2,11 @@ package com.csse3200.game.components.maingame;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.csse3200.game.services.CountdownTimerService;
 import com.csse3200.game.ui.UIComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,10 +14,17 @@ import org.slf4j.LoggerFactory;
 /**
  * Displays a button to exit the Main Game screen to the Main Menu screen.
  */
-public class MainGameExitDisplay extends UIComponent {
-    private static final Logger logger = LoggerFactory.getLogger(MainGameExitDisplay.class);
+public class MainGameDisplay extends UIComponent {
+    private static final Logger logger = LoggerFactory.getLogger(MainGameDisplay.class);
     private static final float Z_INDEX = 2f;
     private Table table;
+
+    private Label timerLabel;
+    private final CountdownTimerService timerService;
+
+    public MainGameDisplay(CountdownTimerService timerService) {
+        this.timerService = timerService;
+    }
 
     @Override
     public void create() {
@@ -25,10 +34,17 @@ public class MainGameExitDisplay extends UIComponent {
 
     private void addActors() {
         table = new Table();
-        table.top().right();
+        table.top();
         table.setFillParent(true);
+        table.setDebug(true);
 
         TextButton mainMenuBtn = new TextButton("Exit", skin);
+
+        timerLabel = new Label("", skin, "large");
+        table.add().expandX();
+        table.add(timerLabel).center().padTop(10f);
+        table.add().expandX();
+
 
         // Triggers an event when the button is pressed.
         mainMenuBtn.addListener(
@@ -40,7 +56,7 @@ public class MainGameExitDisplay extends UIComponent {
                     }
                 });
 
-        table.add(mainMenuBtn).padTop(10f).padRight(10f);
+        table.add(mainMenuBtn).right().padTop(10f).padRight(10f);
 
         stage.addActor(table);
     }
@@ -48,6 +64,11 @@ public class MainGameExitDisplay extends UIComponent {
     @Override
     public void draw(SpriteBatch batch) {
         // draw is handled by the stage
+        long remainingMs = timerService.getRemainingMs();
+        int min = (int) (remainingMs / 60000);
+        int sec = (int) ((remainingMs / 1000) % 60);
+        String timeText = String.format("%02d:%02d", min, sec);
+        timerLabel.setText(timeText);
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/screens/DeathScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/DeathScreen.java
@@ -22,6 +22,7 @@ import com.csse3200.game.services.ServiceLocator;
  * asset loading/unloading, and background creation) is handled by {@link BaseScreen}.
  */
 public class DeathScreen extends BaseScreen {
+    private BaseEndScreenDisplays uiDisplay;
 
     /**
      * Constructs a new DeathScreen instance.
@@ -53,8 +54,13 @@ public class DeathScreen extends BaseScreen {
      */
     @Override
     protected Entity createUIScreen(Stage stage) {
+        uiDisplay = BaseEndScreenDisplays.defeated(game);
         return new Entity()
-                .addComponent(BaseEndScreenDisplays.defeated(game))
+                .addComponent(uiDisplay)
                 .addComponent(new InputDecorator(stage, 10));
+    }
+
+    public void updateTime(long second) {
+        uiDisplay.setElapsedSeconds(second);
     }
 }

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -113,8 +113,10 @@ public class MainGameScreen extends ScreenAdapter {
         if (Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)) {
             if (!isPauseVisible) {
                 showPauseOverlay();
+                countdownTimer.pause();
             } else {
                 hidePauseOverlay();
+                countdownTimer.resume();
             }
         }
 

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -30,6 +30,7 @@ import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.SaveLoadService;
 import com.csse3200.game.services.ServiceLocator;
+import com.csse3200.game.services.CountdownTimerService;
 import com.csse3200.game.ui.terminal.Terminal;
 import com.csse3200.game.ui.terminal.TerminalDisplay;
 import org.slf4j.Logger;
@@ -50,6 +51,8 @@ public class MainGameScreen extends ScreenAdapter {
     private final Renderer renderer;
     private final PhysicsEngine physicsEngine;
     private final GameArea gameArea;
+
+    private CountdownTimerService countdownTimer;
 
 
     private Entity pauseOverlay;
@@ -85,6 +88,8 @@ public class MainGameScreen extends ScreenAdapter {
         gameArea = new ForestGameArea(terrainFactory, renderer.getCamera());
         com.csse3200.game.services.ServiceLocator.registerGameArea(gameArea);
         gameArea.create();
+
+        countdownTimer = new CountdownTimerService(ServiceLocator.getTimeSource(), 60000);
     }
 
     @Override
@@ -111,6 +116,10 @@ public class MainGameScreen extends ScreenAdapter {
             } else {
                 hidePauseOverlay();
             }
+        }
+
+        if (countdownTimer.isTimeUP()) {
+            game.setScreen(ScreenType.DEATH_SCREEN);
         }
     }
 

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -12,7 +12,7 @@ import com.csse3200.game.areas.terrain.TerrainFactory;
 import com.csse3200.game.components.CombatStatsComponent;
 import com.csse3200.game.components.gamearea.PerformanceDisplay;
 import com.csse3200.game.components.maingame.MainGameActions;
-import com.csse3200.game.components.maingame.MainGameExitDisplay;
+import com.csse3200.game.components.maingame.MainGameDisplay;
 import com.csse3200.game.components.player.InventoryComponent;
 import com.csse3200.game.components.player.ItemPickUpComponent;
 import com.csse3200.game.components.screens.PauseMenuDisplay;
@@ -81,6 +81,7 @@ public class MainGameScreen extends ScreenAdapter {
         renderer.getDebug().renderPhysicsWorld(physicsEngine.getWorld());
 
         loadAssets();
+        countdownTimer = new CountdownTimerService(ServiceLocator.getTimeSource(), 60000);
         createUI();
 
         logger.debug("Initialising main game screen entities");
@@ -89,7 +90,6 @@ public class MainGameScreen extends ScreenAdapter {
         com.csse3200.game.services.ServiceLocator.registerGameArea(gameArea);
         gameArea.create();
 
-        countdownTimer = new CountdownTimerService(ServiceLocator.getTimeSource(), 60000);
     }
 
     @Override
@@ -179,7 +179,7 @@ public class MainGameScreen extends ScreenAdapter {
         ui.addComponent(new InputDecorator(stage, 10))
                 .addComponent(new PerformanceDisplay())
                 .addComponent(new MainGameActions(this.game))
-                .addComponent(new MainGameExitDisplay())
+                .addComponent(new MainGameDisplay(countdownTimer))
                 .addComponent(new Terminal(this.game))
                 .addComponent(inputComponent)
                 .addComponent(new TerminalDisplay(this.game));

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -120,6 +120,7 @@ public class MainGameScreen extends ScreenAdapter {
             }
         }
 
+        //switch to death screen when countdown timer is up
         if (countdownTimer.isTimeUP()) {
             setDeathScreen();
         }
@@ -230,10 +231,22 @@ public class MainGameScreen extends ScreenAdapter {
         }
     }
 
+    /**
+     * Calculates the total elapsed time of the countdown timer in second
+     *
+     * @return the elapsed time in seconds
+     */
     private long getCompleteTime(){
         return (countdownTimer.getDuration() - countdownTimer.getRemainingMs()) / 1000;
     }
 
+    /**
+     * Sets the game's screen to death screen
+     *
+     * <p>
+     *     Updates the death screen with the elapsed time before switching.
+     * </p>
+     */
     private void setDeathScreen(){
         DeathScreen deathScreen = new DeathScreen(game);
         deathScreen.updateTime(getCompleteTime());

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -106,7 +106,7 @@ public class MainGameScreen extends ScreenAdapter {
         if (player != null) {
             var playerStat = player.getComponent(CombatStatsComponent.class);
             if (playerStat != null && playerStat.isDead()) {
-                game.setScreen(ScreenType.DEATH_SCREEN);
+                setDeathScreen();
             }
         }
         renderer.render();
@@ -121,7 +121,7 @@ public class MainGameScreen extends ScreenAdapter {
         }
 
         if (countdownTimer.isTimeUP()) {
-            game.setScreen(ScreenType.DEATH_SCREEN);
+            setDeathScreen();
         }
     }
 
@@ -182,7 +182,7 @@ public class MainGameScreen extends ScreenAdapter {
                 .addComponent(new PerformanceDisplay())
                 .addComponent(new MainGameActions(this.game))
                 .addComponent(new MainGameDisplay(countdownTimer))
-                .addComponent(new Terminal(this.game))
+                .addComponent(new Terminal(this.game, countdownTimer))
                 .addComponent(inputComponent)
                 .addComponent(new TerminalDisplay(this.game));
 
@@ -228,6 +228,16 @@ public class MainGameScreen extends ScreenAdapter {
         } else {
             logger.info("Save data failed");
         }
+    }
+
+    private long getCompleteTime(){
+        return (countdownTimer.getDuration() - countdownTimer.getRemainingMs()) / 1000;
+    }
+
+    private void setDeathScreen(){
+        DeathScreen deathScreen = new DeathScreen(game);
+        deathScreen.updateTime(getCompleteTime());
+        game.setScreen(deathScreen);
     }
 
 

--- a/source/core/src/main/com/csse3200/game/screens/WinScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/WinScreen.java
@@ -23,6 +23,7 @@ import com.csse3200.game.services.ServiceLocator;
  * and background creation) is handled by {@link BaseScreen}.
  */
 public class WinScreen extends BaseScreen {
+    private BaseEndScreenDisplays uiDisplay;
     /**
      * Constructs a new WinScreen instance.
      * <p>
@@ -53,9 +54,14 @@ public class WinScreen extends BaseScreen {
      */
     @Override
     protected Entity createUIScreen(Stage stage) {
+        uiDisplay = BaseEndScreenDisplays.victory(game);
         return new Entity()
-                .addComponent(BaseEndScreenDisplays.victory(game))
+                .addComponent(uiDisplay)
                 .addComponent(new InputDecorator(stage, 10));
+    }
+
+    public void updateTime(long second) {
+        uiDisplay.setElapsedSeconds(second);
     }
 }
 

--- a/source/core/src/main/com/csse3200/game/services/CountdownTimerService.java
+++ b/source/core/src/main/com/csse3200/game/services/CountdownTimerService.java
@@ -1,57 +1,147 @@
 package com.csse3200.game.services;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service for managing a countdown timer in a game.
+ * <p>
+ *     This service allows you to track elapsed time, check remaining time,
+ *      pause and resume the countdown, and determine if the timer has expired.
+ * </p>
+ */
 public class CountdownTimerService {
+    private static final Logger logger = LoggerFactory.getLogger(CountdownTimerService.class);
+
+    /**
+     * Tracks the current time in the game
+     */
     private final GameTime gameTime;
+
+    /**
+     * Total duration of the countdown timer in ms
+     * This value is set when the timer is created and does not change
+     */
     private final long duration;
+
+    /**
+     * The timestamp in ms when the countdown timer is started
+     * Updated if the timer is resumed after pause
+     */
     private long startTime;
+
+    /**
+     * The timestamp in ms when the countdown timer is paused
+     */
     private long pauseTime;
+
+    /**
+     * Indicates whether the countdown timer is pausing
+     * True if paused, false if running
+     */
     private boolean paused;
 
+    /**
+     * Creates a new countdown timer
+     *
+     * @param gameTime the {@link GameTime} for tracking time
+     * @param durationMS the duration of the countdown in ms
+     */
     public CountdownTimerService(GameTime gameTime, long durationMS) {
         this.gameTime = gameTime;
         this.duration = durationMS;
         this.startTime = gameTime.getTime();
         this.paused = false;
         this.pauseTime = 0;
+        logger.debug("Setting CountdownTimerService with duration {} ms", duration);
     }
 
-
+    /**
+     * Gets the remaining time in ms
+     *
+     * <p>
+     *     If the timer is paused, calculates based on the paused time;
+     *     otherwise calculates based on teh current game time
+     * </p>
+     *
+     * @return the remaining game time in ms, minimum 0
+     */
     public long getRemainingMs() {
+        long remaining;
         if (isPaused()) {
             long elapsed = pauseTime - startTime;
-            long remaining = duration - elapsed;
-            return Math.max(0, remaining);
+            remaining = duration - elapsed;
+            logger.debug("Timer paused: elapsed time {} ms, remaining time {} ms", elapsed, remaining);
         } else {
             long elapsed = gameTime.getTime() - startTime;
-            long remaining = duration - elapsed;
-            return Math.max(0, remaining);
+            remaining = duration - elapsed;
+            logger.debug("Timer runnign: elapsed time {} ms, remaining time {} ms", elapsed, remaining);
         }
+        return Math.max(0, remaining);
     }
 
+    /**
+     * Checks whether the countdown is finished
+     *
+     * @return true if the timer has reached 0, false otherwise
+     */
     public boolean isTimeUP() {
+        logger.debug("Countdown Time is up: {}", getRemainingMs() <= 0);
         return getRemainingMs() <= 0;
     }
 
+    /**
+     * Pause the countdown timer.
+     *
+     * <p>
+     *     If the time is paused, this method does nothing
+     * </p>
+     */
     public void pause() {
         if (!isPaused()) {
             paused = true;
             pauseTime = gameTime.getTime();
+            logger.debug("Paused Countdown Timer at: {}ms", pauseTime);
+        } else {
+            logger.debug("Called Pause but timer is already paused");
         }
     }
 
+    /**
+     * Resume the counter timer if it was paused
+     *
+     * <p>
+     *     If the timer is not paused, this method does nothing
+     * </p>
+     */
     public void resume() {
         if (paused) {
             long pausedDuration = gameTime.getTime() - pauseTime;
             startTime += pausedDuration;
             paused = false;
+            logger.debug("Resume Countdown, paused duration: {}ms, new start time: {}ms", pausedDuration, startTime);
+        } else {
+            logger.debug("Called Resume but timer is already running");
         }
     }
 
+    /**
+     * Checks if the timer is currently paused
+     *
+     * @return true if paused, false otherwise
+     */
     public boolean isPaused() {
+        logger.debug("Countdown Timer is now paused: {}", paused);
         return paused;
     }
 
+    /**
+     * Get the total duration of the countdown timer
+     *
+     * @return the duration in ms
+     */
     public long getDuration(){
+        logger.debug("Countdown Timer duration: {}", duration);
         return duration;
     }
 }

--- a/source/core/src/main/com/csse3200/game/services/CountdownTimerService.java
+++ b/source/core/src/main/com/csse3200/game/services/CountdownTimerService.java
@@ -50,4 +50,8 @@ public class CountdownTimerService {
     public boolean isPaused() {
         return paused;
     }
+
+    public long getDuration(){
+        return duration;
+    }
 }

--- a/source/core/src/main/com/csse3200/game/services/CountdownTimerService.java
+++ b/source/core/src/main/com/csse3200/game/services/CountdownTimerService.java
@@ -2,7 +2,7 @@ package com.csse3200.game.services;
 
 public class CountdownTimerService {
     private final GameTime gameTime;
-    private long duration;
+    private final long duration;
     private long startTime;
     private long pauseTime;
     private boolean paused;

--- a/source/core/src/main/com/csse3200/game/services/CountdownTimerService.java
+++ b/source/core/src/main/com/csse3200/game/services/CountdownTimerService.java
@@ -4,21 +4,50 @@ public class CountdownTimerService {
     private final GameTime gameTime;
     private long duration;
     private long startTime;
+    private long pauseTime;
+    private boolean paused;
 
     public CountdownTimerService(GameTime gameTime, long durationMS) {
         this.gameTime = gameTime;
         this.duration = durationMS;
         this.startTime = gameTime.getTime();
+        this.paused = false;
+        this.pauseTime = 0;
     }
 
 
     public long getRemainingMs() {
-        long elapsed = gameTime.getTime() - startTime;
-        long remaining = duration - elapsed;
-        return Math.max(0, remaining);
+        if (isPaused()) {
+            long elapsed = pauseTime - startTime;
+            long remaining = duration - elapsed;
+            return Math.max(0, remaining);
+        } else {
+            long elapsed = gameTime.getTime() - startTime;
+            long remaining = duration - elapsed;
+            return Math.max(0, remaining);
+        }
     }
 
     public boolean isTimeUP() {
         return getRemainingMs() <= 0;
+    }
+
+    public void pause() {
+        if (!isPaused()) {
+            paused = true;
+            pauseTime = gameTime.getTime();
+        }
+    }
+
+    public void resume() {
+        if (paused) {
+            long pausedDuration = gameTime.getTime() - pauseTime;
+            startTime += pausedDuration;
+            paused = false;
+        }
+    }
+
+    public boolean isPaused() {
+        return paused;
     }
 }

--- a/source/core/src/main/com/csse3200/game/services/CountdownTimerService.java
+++ b/source/core/src/main/com/csse3200/game/services/CountdownTimerService.java
@@ -1,0 +1,24 @@
+package com.csse3200.game.services;
+
+public class CountdownTimerService {
+    private final GameTime gameTime;
+    private long duration;
+    private long startTime;
+
+    public CountdownTimerService(GameTime gameTime, long durationMS) {
+        this.gameTime = gameTime;
+        this.duration = durationMS;
+        this.startTime = gameTime.getTime();
+    }
+
+
+    public long getRemainingMs() {
+        long elapsed = gameTime.getTime() - startTime;
+        long remaining = duration - elapsed;
+        return Math.max(0, remaining);
+    }
+
+    public boolean isTimeUP() {
+        return getRemainingMs() <= 0;
+    }
+}

--- a/source/core/src/main/com/csse3200/game/ui/terminal/Terminal.java
+++ b/source/core/src/main/com/csse3200/game/ui/terminal/Terminal.java
@@ -2,6 +2,7 @@ package com.csse3200.game.ui.terminal;
 
 import com.csse3200.game.GdxGame;
 import com.csse3200.game.components.Component;
+import com.csse3200.game.services.CountdownTimerService;
 import com.csse3200.game.ui.terminal.autocomplete.BKTree;
 import com.csse3200.game.ui.terminal.autocomplete.RadixTrie;
 import com.csse3200.game.ui.terminal.commands.*;
@@ -17,6 +18,9 @@ public class Terminal extends Component {
     private String enteredMessage = "";
     private boolean isOpen = false;
 
+    private final CountdownTimerService countdownTimer;
+
+
     // --- Autocomplete state ---
     private final RadixTrie trie = new RadixTrie();
     private final BKTree bkTree = new BKTree();
@@ -31,23 +35,28 @@ public class Terminal extends Component {
     private List<String> lastSuggestions = Collections.emptyList();
 
     public Terminal() {
-        this(new HashMap<>(), null);
+        this(new HashMap<>(), null, null);
     }
 
     public Terminal(GdxGame game) {
-        this(new HashMap<>(), game);
+        this(new HashMap<>(), game, null);
     }
 
     public Terminal(Map<String, Command> commands) {
-        this(commands, null);
+        this(commands, null, null);
     }
 
-    public Terminal(Map<String, Command> commands, GdxGame game) {
+    public Terminal(GdxGame game, CountdownTimerService timer) {
+        this(new HashMap<>(), game, timer);
+    }
+
+    public Terminal(Map<String, Command> commands, GdxGame game, CountdownTimerService timer) {
         this.commands = commands;
+        this.countdownTimer = timer;
 
         addCommand("debug", new DebugCommand());
-        addCommand("winscreen", new EndScreenCommand(game, GdxGame.ScreenType.WIN_SCREEN));
-        addCommand("deathscreen", new EndScreenCommand(game, GdxGame.ScreenType.DEATH_SCREEN));
+        addCommand("winscreen", new EndScreenCommand(game, GdxGame.ScreenType.WIN_SCREEN, countdownTimer));
+        addCommand("deathscreen", new EndScreenCommand(game, GdxGame.ScreenType.DEATH_SCREEN, countdownTimer));
         addCommand("disableDamage", new DisableDamageCommand());
         addCommand("waves", new WavesCommand());
         addCommand("damageMultiplier", new DamageMultiplierCommand());

--- a/source/core/src/main/com/csse3200/game/ui/terminal/commands/EndScreenCommand.java
+++ b/source/core/src/main/com/csse3200/game/ui/terminal/commands/EndScreenCommand.java
@@ -1,6 +1,9 @@
 package com.csse3200.game.ui.terminal.commands;
 
 import com.csse3200.game.GdxGame;
+import com.csse3200.game.screens.DeathScreen;
+import com.csse3200.game.screens.WinScreen;
+import com.csse3200.game.services.CountdownTimerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,13 +12,29 @@ import java.util.ArrayList;
 /**
  * A command for switching to the Win Screen or other end screens.
  */
-public record EndScreenCommand(GdxGame game, GdxGame.ScreenType screenType) implements Command {
+public record EndScreenCommand(GdxGame game, GdxGame.ScreenType screenType,
+                               CountdownTimerService timer) implements Command {
     private static final Logger logger = LoggerFactory.getLogger(EndScreenCommand.class);
 
     @Override
     public boolean action(ArrayList<String> args) {
         logger.info("Switching to {}", screenType);
-        game.setScreen(screenType);
-        return true;
+        long elapsedSeconds = (timer.getDuration() - timer.getRemainingMs()) / 1000;
+        switch (screenType) {
+            case DEATH_SCREEN:
+                DeathScreen deathScreen = new DeathScreen(game);
+                deathScreen.updateTime(elapsedSeconds);
+                game.setScreen(deathScreen);
+                return true;
+            case WIN_SCREEN:
+                WinScreen winScreen = new WinScreen(game);
+                winScreen.updateTime(elapsedSeconds);
+                game.setScreen(winScreen);
+                return true;
+            default:
+                logger.debug("Unrecognised argument received for 'Screen' command: {}", args);
+                return false;
+        }
+
     }
 }

--- a/source/core/src/test/com/csse3200/game/services/CountdownTimerServiceTest.java
+++ b/source/core/src/test/com/csse3200/game/services/CountdownTimerServiceTest.java
@@ -1,0 +1,78 @@
+package com.csse3200.game.services;
+
+import com.csse3200.game.extensions.GameExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(GameExtension.class)
+class CountdownTimerServiceTest {
+    GameTime mockGameTime;
+    CountdownTimerService timer;
+
+    @BeforeEach
+    void beforeEach() {
+        mockGameTime = mock(GameTime.class);
+        when(mockGameTime.getTime()).thenReturn(0L);
+        timer = new CountdownTimerService(mockGameTime, 5000);
+    }
+
+    @Test
+    void testStartingGameRemainingTime() {
+        assertEquals(5000, timer.getRemainingMs(), "Full duration at start: 5 seconds");
+        assertFalse(timer.isTimeUP(), "Timer should report time is not up");
+    }
+    @Test
+    void testCountdown() {
+        when(mockGameTime.getTime()).thenReturn(2000L);
+        assertEquals(3000, timer.getRemainingMs(), "Remaining time: 3 seconds");
+        assertFalse(timer.isTimeUP(), "Timer should report time is not up");
+    }
+
+    @Test
+    void testTimesUp() {
+        when(mockGameTime.getTime()).thenReturn(5000L);
+        assertEquals(0, timer.getRemainingMs(), "Remaining time: 0 seconds");
+        assertTrue(timer.isTimeUP(), "Timer should report time is up");
+    }
+
+    @Test
+    void testHandleNegativeRemainingTime() {
+        when(mockGameTime.getTime()).thenReturn(6000L);
+        assertEquals(0, timer.getRemainingMs(), "Remaining should not be negative");
+        assertTrue(timer.isTimeUP(), "Timer should report time is up");
+    }
+
+    @Test
+    void testPauseAndResumeTimer() {
+        when(mockGameTime.getTime()).thenReturn(2000L);
+        assertEquals(3000, timer.getRemainingMs(), "Remaining time: 3 seconds");
+        timer.pause();
+
+        when(mockGameTime.getTime()).thenReturn(4000L);
+        assertEquals(3000, timer.getRemainingMs(), "Timer Paused, Remaining time does not change: 3 seconds");
+
+        timer.resume();
+        when(mockGameTime.getTime()).thenReturn(6000L);
+        assertEquals(1000, timer.getRemainingMs(), "Timer Resumed, Remaining time: 1 seconds");
+
+    }
+
+    @Test
+    void testIsPausedFlag() {
+        assertFalse(timer.isPaused(), "Start game not paused");
+        timer.pause();
+        assertTrue(timer.isPaused(), "Should be paused after pause()");
+        timer.resume();
+        assertFalse(timer.isPaused(), "Should not be paused after resume()");
+    }
+
+    @Test
+    void testGetDuration() {
+        assertEquals(5000, timer.getDuration(), "Duration should match constructor input");
+    }
+}

--- a/source/core/src/test/com/csse3200/game/ui/terminal/commands/EndScreenCommandTests.java
+++ b/source/core/src/test/com/csse3200/game/ui/terminal/commands/EndScreenCommandTests.java
@@ -1,16 +1,21 @@
 package com.csse3200.game.ui.terminal.commands;
 
+import com.badlogic.gdx.Screen;
 import com.csse3200.game.GdxGame;
+import com.csse3200.game.extensions.GameExtension;
+import com.csse3200.game.screens.DeathScreen;
+import com.csse3200.game.screens.WinScreen;
+import com.csse3200.game.services.CountdownTimerService;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(GameExtension.class)
 class EndScreenCommandTests {
 
     private static boolean run(Command cmd, String... args) {
@@ -20,14 +25,122 @@ class EndScreenCommandTests {
     @Test
     void switchesScreenAndReturnsTrue() {
         GdxGame game = mock(GdxGame.class);
-        EndScreenCommand cmd = new EndScreenCommand(game, GdxGame.ScreenType.WIN_SCREEN);
+        CountdownTimerService timer = mock(CountdownTimerService.class);
+        when(timer.getDuration()).thenReturn(60_000L);
+        when(timer.getRemainingMs()).thenReturn(15_000L);
+
+        WinScreen win = mock(WinScreen.class);
+        when(game.getScreen()).thenReturn(win);
+
+        EndScreenCommand cmd = new EndScreenCommand(game, GdxGame.ScreenType.WIN_SCREEN, timer);
 
         boolean ok = run(cmd);
-        assertTrue(ok, "action should return true");
+        assertTrue(ok);
 
-        ArgumentCaptor<GdxGame.ScreenType> cap = ArgumentCaptor.forClass(GdxGame.ScreenType.class);
-        verify(game, times(1)).setScreen(cap.capture());
-        assertEquals(GdxGame.ScreenType.WIN_SCREEN, cap.getValue());
+        verify(game).setScreen(GdxGame.ScreenType.WIN_SCREEN);
+        verify(game).getScreen();
+        verify(win).updateTime(45L);
+
+        verify(timer, atLeastOnce()).getDuration();
+        verify(timer, atLeastOnce()).getRemainingMs();
+        verifyNoMoreInteractions(game);
+    }
+
+    @Test
+    void switchesToDeathAndUpdatesTime() {
+        GdxGame game = mock(GdxGame.class);
+        CountdownTimerService timer = mock(CountdownTimerService.class);
+        // 90s total, 10s remaining => 80s elapsed
+        when(timer.getDuration()).thenReturn(90_000L);
+        when(timer.getRemainingMs()).thenReturn(10_000L);
+
+        DeathScreen death = mock(DeathScreen.class);
+        when(game.getScreen()).thenReturn(death);
+
+        EndScreenCommand cmd = new EndScreenCommand(game, GdxGame.ScreenType.DEATH_SCREEN, timer);
+
+        boolean ok = run(cmd);
+        assertTrue(ok);
+
+        verify(game).setScreen(GdxGame.ScreenType.DEATH_SCREEN);
+        verify(game).getScreen();
+        verify(death).updateTime(80L);
+
+        verify(timer, atLeastOnce()).getDuration();
+        verify(timer, atLeastOnce()).getRemainingMs();
+        verifyNoMoreInteractions(game);
+    }
+
+    @Test
+    void winScreenHandlesNullCurrentScreenGracefully() {
+        GdxGame game = mock(GdxGame.class);
+        CountdownTimerService timer = mock(CountdownTimerService.class);
+        when(timer.getDuration()).thenReturn(30_000L);
+        when(timer.getRemainingMs()).thenReturn(5_000L);
+
+        // Router hasn’t populated current screen yet
+        when(game.getScreen()).thenReturn(null);
+
+        EndScreenCommand cmd = new EndScreenCommand(game, GdxGame.ScreenType.WIN_SCREEN, timer);
+
+        boolean ok = run(cmd);
+        assertTrue(ok);
+
+        verify(game).setScreen(GdxGame.ScreenType.WIN_SCREEN);
+        verify(game).getScreen(); // called but null → no updateTime call
+        verify(timer, atLeastOnce()).getDuration();
+        verify(timer, atLeastOnce()).getRemainingMs();
+        verifyNoMoreInteractions(game);
+    }
+
+    @Test
+    void winScreenOtherScreenType_NoUpdateCalled() {
+        GdxGame game = mock(GdxGame.class);
+        CountdownTimerService timer = mock(CountdownTimerService.class);
+        when(timer.getDuration()).thenReturn(10_000L);
+        when(timer.getRemainingMs()).thenReturn(2_000L);
+
+        // Some other Screen implementation (not WinScreen/DeathScreen)
+        Screen other = mock(Screen.class);
+        when(game.getScreen()).thenReturn(other);
+
+        EndScreenCommand cmd = new EndScreenCommand(game, GdxGame.ScreenType.WIN_SCREEN, timer);
+
+        boolean ok = run(cmd);
+        assertTrue(ok);
+
+        verify(game).setScreen(GdxGame.ScreenType.WIN_SCREEN);
+        verify(game).getScreen();
+        // No methods on this generic Screen should be called by EndScreenCommand
+        verifyNoInteractions(other);
+
+        verify(timer, atLeastOnce()).getDuration();
+        verify(timer, atLeastOnce()).getRemainingMs();
+        verifyNoMoreInteractions(game);
+    }
+
+    @Test
+    void elapsedSecondsCanBeNegative_PassedThroughAsIs() {
+        GdxGame game = mock(GdxGame.class);
+        CountdownTimerService timer = mock(CountdownTimerService.class);
+        // Remaining > duration → negative elapsed
+        when(timer.getDuration()).thenReturn(5_000L);
+        when(timer.getRemainingMs()).thenReturn(8_000L); // elapsed = -3s
+
+        WinScreen win = mock(WinScreen.class);
+        when(game.getScreen()).thenReturn(win);
+
+        EndScreenCommand cmd = new EndScreenCommand(game, GdxGame.ScreenType.WIN_SCREEN, timer);
+
+        boolean ok = run(cmd);
+        assertTrue(ok);
+
+        verify(game).setScreen(GdxGame.ScreenType.WIN_SCREEN);
+        verify(game).getScreen();
+        verify(win).updateTime(-3L); // current implementation passes negative through
+
+        verify(timer, atLeastOnce()).getDuration();
+        verify(timer, atLeastOnce()).getRemainingMs();
         verifyNoMoreInteractions(game);
     }
 }


### PR DESCRIPTION
# Description
This PR implements the Countdown Timer feature and integrates it into both the main game display and the end screens.

- Adds a CountdownTimer service that tracks elapsed and remaining time, with support for pause/resume.
- Displays the countdown time (in MM:SS format) during gameplay.
- Triggers game loss automatically when the timer reaches zero
- Passes completion/ survival time to WinScreen and DeathScreen so that it is shown to the player.

Fixes / Closes # (issue)
#214 
#265 
#266 

## Type of change

- [ xx] New feature (non-breaking change which adds functionality)

- [ x ] This change requires a documentation update

# How Has This Been Tested?
Unit Test:
- [ x ] [CountdownTimerService unit test](https://github.com/UQcsse3200/2025-studio-1/blob/timer/source/core/src/test/com/csse3200/game/services/CountdownTimerServiceTest.java)

Manual playtest to verify in-game behaviour:
- [ x ] Timer display in main game tested to ensure correct formatting (MM:SS)
- [ x ] End screens tested to confirm elapsed time is correctly passed
- [ x ] Timer correct completion time shown on endscreen
- [ x ] Timer correct hooks into game's state of pause and resume
- [ x ] Game ends automatically when timer reaches zero

# Checklist:

- [ ] My code follows the style guidelines of this project

- [ ] I have performed a self-review of my code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] My changes generate no new warnings

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New and existing unit tests pass locally with my changes

- [ ] Any dependent changes have been merged and published in downstream modules
