### PR TITLE
Fixed issue causing PlayerActions to be created twice

### DIFF
--- a/source/core/src/main/com/csse3200/game/entities/factories/characters/PlayerFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/characters/PlayerFactory.java
@@ -87,11 +87,6 @@ public class PlayerFactory {
         player.getComponent(WeaponsStatsComponent.class).setCoolDown(0.2f);
 
 
-        //Unequip player at spawn
-        PlayerActions actions = player.getComponent(PlayerActions.class);
-        actions.create();
-
-
         // pick up rapid fire powerup
         // remove this if we have item pickup available
         // (disposes entity when player go near it)


### PR DESCRIPTION
# Description

As the title says, this PR removes three lines and fixes the existing double jump bug by removing lines that caused the PlayerActions component to be created twice, resulting in duplicated handling of jump events and likely other bugs.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Passes existing unit tests

- [X] Visual/manual testing in game shows that it fixes the issue

# Checklist:

- [X] My code follows the style guidelines of this project

- [X] I have performed a self-review of my code

- [X] I have commented my code, particularly in hard-to-understand areas

- [X] I have made corresponding changes to the documentation

- [X] My changes generate no new warnings

- [X] I have added tests that prove my fix is effective or that my feature works

- [X] New and existing unit tests pass locally with my changes

- [X] Any dependent changes have been merged and published in downstream modules
