### PR TITLE
Fixed minimap not closing bug

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/screens/MinimapDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/screens/MinimapDisplay.java
@@ -4,7 +4,6 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.csse3200.game.GdxGame;
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;


### PR DESCRIPTION
# Description

Due to the addition of a `setkeyboardfocus(root)` in one of the other features, minimap was unable to be closed. This has now been fixed. 

Fixes #320 
Closes #320 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- The functionality has been tested through in-game debugging sessions.
- Manual testing of the UI of mini map so as to ensure that the right things are being displayed and the functionalities of zoom in and dragging work as intended.

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
