### PR TITLE
disposes of recourses in the screen properly

### DIFF
--- a/source/core/src/main/com/csse3200/game/screens/AvatarChoiceScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/AvatarChoiceScreen.java
@@ -218,6 +218,30 @@ public class AvatarChoiceScreen extends BaseScreen {
     @Override
     public void dispose() {
         super.dispose();
-        for (Texture t : loadedTextures) t.dispose();
+        if (Gdx.input.getInputProcessor() == stage) {
+            Gdx.input.setInputProcessor(null);
+        }
+
+        // Manually loaded textures for avatar cards
+        if (loadedTextures != null) {
+            for (Texture t : loadedTextures) {
+                if (t != null) t.dispose();
+            }
+            loadedTextures.clear();
+            loadedTextures = null;
+        }
+
+        // Dispose UI skin (also frees its atlas/bitmaps)
+        if (skin != null) {
+            skin.dispose();
+            skin = null;
+        }
+
+        // Clear actors/listeners, then dispose the stage and its batch
+        if (stage != null) {
+            stage.clear();     // removes actors & listeners
+            stage.dispose();   // disposes internal Batch since we created the Stage
+            stage = null;
+        }
     }
 }


### PR DESCRIPTION
# Description
small bug fix where the screen recourses allocated while the player choosing the screen is not actually freed after the user is done


Fixes / Closes # (issue)
#383

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
