### PR TITLE
Changed processor values dropped by enemies to balance game

### DIFF
--- a/source/core/src/main/com/csse3200/game/entities/factories/characters/NPCFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/characters/NPCFactory.java
@@ -27,8 +27,6 @@ import com.csse3200.game.physics.components.PhysicsMovementComponent;
 import com.csse3200.game.rendering.AnimationRenderComponent;
 import com.csse3200.game.services.ServiceLocator;
 
-import java.io.IOException;
-
 /**
  * Factory to create non-playable character (NPC) entities with predefined components.
  *
@@ -43,8 +41,8 @@ public class NPCFactory {
     private static final NPCConfigs configs =
             FileLoader.readClass(NPCConfigs.class, "configs/NPCs.json");
 
-    private static final int baseDeathReward = 100;
-    private static final int variantDeathReward = 150;
+    private static final int BASE_DEATH_REWARD = 100;
+    private static final int VARIANT_DEATH_REWARD = 150;
 
     private NPCFactory() {
         throw new IllegalStateException("Instantiating static util class");
@@ -109,7 +107,7 @@ public class NPCFactory {
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
                 .addComponent(new LowHealthAttackBuffComponent(10, ghostGPTStats))
-                .addComponent(new EnemyDeathRewardComponent(baseDeathReward, playerInventory)) // Add reward + particles
+                .addComponent(new EnemyDeathRewardComponent(BASE_DEATH_REWARD, playerInventory)) // Add reward + particles
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(aiComponent)
                 .addComponent(projComp) // Add the ability to fire projectiles
@@ -172,7 +170,7 @@ public class NPCFactory {
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
                 .addComponent(new LowHealthAttackBuffComponent(10, ghostGPTRedStats))
-                .addComponent(new EnemyDeathRewardComponent(variantDeathReward, playerInventory)) // Add reward + particles
+                .addComponent(new EnemyDeathRewardComponent(VARIANT_DEATH_REWARD, playerInventory)) // Add reward + particles
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(aiComponent)
                 .addComponent(projComp) // Add the ability to fire projectiles
@@ -235,7 +233,7 @@ public class NPCFactory {
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
                 .addComponent(new LowHealthAttackBuffComponent(10, ghostGPTBlueStats))
-                .addComponent(new EnemyDeathRewardComponent(variantDeathReward, playerInventory)) // Add reward + particles
+                .addComponent(new EnemyDeathRewardComponent(VARIANT_DEATH_REWARD, playerInventory)) // Add reward + particles
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(aiComponent)
                 .addComponent(projComp) // Add the ability to fire projectiles
@@ -319,7 +317,7 @@ public class NPCFactory {
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
                 .addComponent(new LowHealthAttackBuffComponent(10, deepspinAttack))
-                .addComponent(new EnemyDeathRewardComponent(baseDeathReward, playerInventory)) // Add reward + particles
+                .addComponent(new EnemyDeathRewardComponent(BASE_DEATH_REWARD, playerInventory)) // Add reward + particles
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(aiComponent)
                 .addComponent(new EnemyHealthDisplay())
@@ -376,7 +374,7 @@ public class NPCFactory {
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
                 .addComponent(new LowHealthAttackBuffComponent(10, deepspinRedAttack))
-                .addComponent(new EnemyDeathRewardComponent(variantDeathReward, playerInventory)) // Add reward + particles
+                .addComponent(new EnemyDeathRewardComponent(VARIANT_DEATH_REWARD, playerInventory)) // Add reward + particles
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(aiComponent)
                 .addComponent(new EnemyHealthDisplay())
@@ -433,7 +431,7 @@ public class NPCFactory {
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
                 .addComponent(new LowHealthAttackBuffComponent(10, deepspinBlueAttack))
-                .addComponent(new EnemyDeathRewardComponent(variantDeathReward, playerInventory)) // Add reward + particles
+                .addComponent(new EnemyDeathRewardComponent(VARIANT_DEATH_REWARD, playerInventory)) // Add reward + particles
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(aiComponent)
                 .addComponent(new EnemyHealthDisplay())
@@ -490,7 +488,7 @@ public class NPCFactory {
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
                 .addComponent(new LowHealthAttackBuffComponent(10, grokDroidWeapon))
-                .addComponent(new EnemyDeathRewardComponent(baseDeathReward, playerInventory)) // Add reward + particles
+                .addComponent(new EnemyDeathRewardComponent(BASE_DEATH_REWARD, playerInventory)) // Add reward + particles
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(aiComponent)
                 .addComponent(new EnemyHealthDisplay(0.3f))
@@ -547,7 +545,7 @@ public class NPCFactory {
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
                 .addComponent(new LowHealthAttackBuffComponent(10, grokDroidRedWeapon))
-                .addComponent(new EnemyDeathRewardComponent(variantDeathReward, playerInventory)) // Add reward + particles
+                .addComponent(new EnemyDeathRewardComponent(VARIANT_DEATH_REWARD, playerInventory)) // Add reward + particles
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(aiComponent)
                 .addComponent(new EnemyHealthDisplay(0.3f))
@@ -604,7 +602,7 @@ public class NPCFactory {
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
                 .addComponent(new LowHealthAttackBuffComponent(10, grokDroidBlueWeapon))
-                .addComponent(new EnemyDeathRewardComponent(variantDeathReward, playerInventory)) // Add reward + particles
+                .addComponent(new EnemyDeathRewardComponent(VARIANT_DEATH_REWARD, playerInventory)) // Add reward + particles
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(aiComponent)
                 .addComponent(new EnemyHealthDisplay(0.3f))
@@ -669,7 +667,7 @@ public class NPCFactory {
                 .addComponent(new WeaponsStatsComponent((int) (config.baseAttack * scalingFactor)))
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
-                .addComponent(new EnemyDeathRewardComponent(baseDeathReward, playerInventory))
+                .addComponent(new EnemyDeathRewardComponent(BASE_DEATH_REWARD, playerInventory))
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(new VroombaSuicideComponent(target, triggerRadius, damageRadius, boomDamage, fuseSeconds))
                 .addComponent(aiComponent)
@@ -734,7 +732,7 @@ public class NPCFactory {
                 .addComponent(new WeaponsStatsComponent((int) (config.baseAttack * scalingFactor)))
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
-                .addComponent(new EnemyDeathRewardComponent(variantDeathReward, playerInventory))
+                .addComponent(new EnemyDeathRewardComponent(VARIANT_DEATH_REWARD, playerInventory))
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(new VroombaSuicideComponent(target, triggerRadius, damageRadius, boomDamage, fuseSeconds))
                 .addComponent(aiComponent)
@@ -799,7 +797,7 @@ public class NPCFactory {
                 .addComponent(new WeaponsStatsComponent((int) (config.baseAttack * scalingFactor)))
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
-                .addComponent(new EnemyDeathRewardComponent(variantDeathReward, playerInventory))
+                .addComponent(new EnemyDeathRewardComponent(VARIANT_DEATH_REWARD, playerInventory))
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(new VroombaSuicideComponent(target, triggerRadius, damageRadius, boomDamage, fuseSeconds))
                 .addComponent(aiComponent)
@@ -864,7 +862,7 @@ public class NPCFactory {
                 .addComponent(animator)
                 .addComponent(new GhostAnimationController())
                 .addComponent(new LowHealthAttackBuffComponent(10, turretStats))
-                .addComponent(new EnemyDeathRewardComponent(baseDeathReward, playerInventory)) // Add reward + particles
+                .addComponent(new EnemyDeathRewardComponent(BASE_DEATH_REWARD, playerInventory)) // Add reward + particles
                 .addComponent(new DeathParticleSpawnerComponent("explosion_2"))
                 .addComponent(aiComponent)
                 .addComponent(projComp) // Add the ability to fire projectiles


### PR DESCRIPTION
# Description

This pull request addresses the change to the enemy death reward, that is, all base variants of enemies now drop 100 processors on death and all variants (blue and red) drop 150 processors on death.

Fixes / Closes #430 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

There are existing tests which test the death reward component (EnemyDeathRewardComponentTest.java) and this change has been tested during in game debugging sessions where upon killing a base variant enemy, the player gains 100 processors and upon killing a variant, the player gains 150 processors. 

# Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes

- [x] Any dependent changes have been merged and published in downstream modules
